### PR TITLE
Minor Changes

### DIFF
--- a/DevOps_Acceleration_Program/resources.html
+++ b/DevOps_Acceleration_Program/resources.html
@@ -486,7 +486,6 @@
     .abstract-text{
       padding-top: 5px;
       padding-left: 5px;
-      width: 140%;
     }
   </style>
   <div style="display:none">page-templates/empty.php</div>
@@ -1363,7 +1362,7 @@
                         </th>
                         <th width="30%" class="sorting_asc" tabindex="1" aria-controls="languagestable" rowspan="1"
                           colspan="1" aria-sort="ascending" aria-label="Resource Type">
-                          Resource Type
+                          Resource Type(s)
                         </th>
                         <th width="15%" class="sorting_asc" tabindex="2" aria-controls="languagestable" rowspan="1"
                           colspan="1" aria-sort="ascending" aria-label="Date">
@@ -1427,7 +1426,7 @@
                         </td>
                         <td>
                           <p>
-                            Whitepapers / TechDocs & Migration
+                            Whitepapers/TechDocs & Migration
                           </p>
                         </td>
                         <td>
@@ -1456,7 +1455,7 @@
                         </td>
                         <td>
                           <p>
-                            Orchestrator & Whitepapers / TechDocs
+                            Orchestrator & Whitepapers/TechDocs
                           </p>
                         </td>
                         <td>
@@ -1600,7 +1599,7 @@
                         </td>
                         <td>
                           <p>
-                            Tutorial & Whitepapers / TechDocs
+                            Tutorial & Whitepapers/TechDocs
                           </p>
                         </td>
                         <td>
@@ -1678,7 +1677,7 @@
                         </td>
                         <td>
                           <p>
-                            Whitepapers / TechDocs 
+                            Whitepapers/TechDocs 
                           </p>
                         </td>
                         <td>
@@ -1707,7 +1706,7 @@
                         </td>
                         <td>
                           <p>
-                            Getting Started & Whitepapers / TechDocs
+                            Getting Started & Whitepapers/TechDocs
                           </p>
                         </td>
                         <td>
@@ -1739,7 +1738,7 @@
                         </td>
                         <td>
                           <p>
-                            Getting Started & Whitepapers / TechDocs
+                            Getting Started & Whitepapers/TechDocs
                           </p>
                         </td>
                         <td>
@@ -1770,7 +1769,7 @@
                         </td>
                         <td>
                           <p>
-                            Getting Started & Whitepapers / TechDocs
+                            Getting Started & Whitepapers/TechDocs
                           </p>
                         </td>
                         <td>
@@ -1806,7 +1805,7 @@
                         </td>
                         <td>
                           <p>
-                            Getting Started & Whitepapers / TechDocs
+                            Getting Started & Whitepapers/TechDocs
                           </p>
                         </td>
                         <td>
@@ -1984,7 +1983,7 @@
                         </td>
                         <td>
                           <p>
-                            Whitepapers / TechDocs & zAppBuild
+                            Whitepapers/TechDocs & zAppBuild
                           </p>
                         </td>
                         <td>
@@ -2022,7 +2021,7 @@
                         </td>
                         <td>
                           <p>
-                            Migration, Whitepapers / TechDocs, & zAppBuild
+                            Migration, Whitepapers/TechDocs, & zAppBuild
                           </p>
                         </td>
                         <td>
@@ -2055,7 +2054,7 @@
                         </td>
                         <td>
                           <p>
-                            Design & Whitepapers / TechDocs
+                            Design & Whitepapers/TechDocs
                           </p>
                         </td>
                         <td>
@@ -2126,7 +2125,7 @@
                         </td>
                         <td>
                           <p>
-                            Design & Whitepapers / TechDocs
+                            Design & Whitepapers/TechDocs
                           </p>
                         </td>
                         <td>
@@ -2160,7 +2159,7 @@
                         </td>
                         <td>
                           <p>
-                            Orchestrator & Whitepapers / TechDocs
+                            Orchestrator & Whitepapers/TechDocs
                           </p>
                         </td>
                         <td>
@@ -2194,7 +2193,7 @@
                         </td>
                         <td>
                           <p>
-                            Orchestrator & Whitepapers / TechDocs
+                            Orchestrator & Whitepapers/TechDocs
                           </p>
                         </td>
                         <td>
@@ -2226,7 +2225,7 @@
                         </td>
                         <td>
                           <p>
-                            Orchestrator & Whitepapers / TechDocs
+                            Orchestrator & Whitepapers/TechDocs
                           </p>
                         </td>
                         <td>
@@ -2258,7 +2257,7 @@
                         </td>
                         <td>
                           <p>
-                            Tools & Whitepapers / TechDocs
+                            Tools & Whitepapers/TechDocs
                           </p>
                         </td>
                         <td>


### PR DESCRIPTION
Removed extra spacing in "Whitepapers/TechDocs"
Adjusted width of resource abstracts to be in line with resource titles
Changed "Resource Type" to "Resource Type(s)"