### PR TITLE
Various Updates

### DIFF
--- a/DevOps_Acceleration_Program/devops-acceleration-program.html
+++ b/DevOps_Acceleration_Program/devops-acceleration-program.html
@@ -1640,30 +1640,7 @@
                                         </div>
                                     </div> -->
 
-                                <!-- Atlas-->
-                                <!--<div class="ibm-col-4-1 ibm-col-medium-4-3">-->
-                                <div class="ibm-col-12-3 ibm-col-medium-12-12">
-                                  <div
-                                    class="ibm-card dl-card"
-                                    style="height: 196.8px;"
-                                  >
-                                    <div class="ibm-card__content">
-                                      <h3>IBM Z DevOps Village</h3>
-                                    </div>
-                                    <div class="ibm-card__bottom">
-                                      <p
-                                        class="ibm-btn-row ibm-ind-link ibm-button-link"
-                                      >
-                                        <a
-                                          href="ibm-z-devops-village.html"
-                                          class="ibm-btn-sec ibm-information-link ibm-btn-blue-50"
-                                          tabindex="0"
-                                          >More info</a
-                                        >
-                                      </p>
-                                    </div>
-                                  </div>
-                                </div>
+                                
 
                                 <!-- ADFz host component-->
                                 <div class="ibm-col-12-3 ibm-col-medium-12-12">

--- a/Training/adfz-learning-resources.html
+++ b/Training/adfz-learning-resources.html
@@ -1420,7 +1420,7 @@
           <li><a href="https://community.ibm.com/community/user/ibmz-and-linuxone/viewdocument/commentuncomment-a-contiguous-bloc?CommunityKey=b0dae4a8-74eb-44ac-86c7-90f3cd32909a" target="_blank" rel="noopener">Comment - Uncomment</a></li>
           <li><a href="https://community.ibm.com/community/user/ibmz-and-linuxone/viewdocument/split-screen-lpex-editor?CommunityKey=b0dae4a8-74eb-44ac-86c7-90f3cd32909a" target="_blank" rel="noopener">Editing in Split Screen Mode</a></li>
           <li><a href="https://community.ibm.com/community/user/ibmz-and-linuxone/viewdocument/uppercase-an-ispfedit-compatib?CommunityKey=b0dae4a8-74eb-44ac-86c7-90f3cd32909a" target="_blank" rel="noopener">Upper Case ALL</a></li>
-          <li><a href="https://community.ibm.com/community/user/ibmz-and-linuxone/viewdocument/hex-editing-source-code-with-lpex?CommunityKey=b0dae4a8-74eb-44ac-86c7-90f3cd32909a&amp;tab=librarydocuments" target="_blank" rel="noopener">HexEdit - Editing Files with Binary Characters - LPEX</a></li>
+          <li><a href="https://community.ibm.com/community/user/ibmz-and-linuxone/viewdocument/hex-editing-in-the-lpex-editor?CommunityKey=b0dae4a8-74eb-44ac-86c7-90f3cd32909a&tab=librarydocuments" target="_blank" rel="noopener">Hex Editing in the LPEX Editor </a></li>
           <li><a href="https://community.ibm.com/community/user/ibmz-and-linuxone/viewdocument/hexedit-editing-files-with-binary?CommunityKey=b0dae4a8-74eb-44ac-86c7-90f3cd32909a" target="_blank" rel="noopener">HexEdit - Editing Files with Binary Characters - Java-Style COBOL and PL/I Editors</a></li>
           <li><a href="https://community.ibm.com/community/user/ibmz-and-linuxone/viewdocument/lpex-code-filters?CommunityKey=b0dae4a8-74eb-44ac-86c7-90f3cd32909a" target="_blank" rel="noopener">LPEX Filters (Comments, SQL, Copybooks, Calls)</a></li>
           <li><a href="https://community.ibm.com/community/user/ibmz-and-linuxone/viewdocument/auto-commenting-changed-lines?CommunityKey=b0dae4a8-74eb-44ac-86c7-90f3cd32909a&amp;tab=librarydocuments" target="_blank" rel="noopener">Auto Commenting Changed Lines</a><a href="https://developer.ibm.com/mainframe/videos/ibm-developer-z-systems-autocommenting-feature" target="_blank" rel="noopener"><br></a></li>
@@ -1441,7 +1441,7 @@
           <div class="ibm-container-body" style="display: none;">
           <ul>
           <li><a href="https://community.ibm.com/community/user/ibmz-and-linuxone/viewdocument/extended-ispf-editing-setup-prog?CommunityKey=b0dae4a8-74eb-44ac-86c7-90f3cd32909a&amp;tab=librarydocuments" target="_blank" rel="noopener">IDz/LPEX Deep-Dive - Setup, Configuration and Preferences for ISPF Editing</a></li>
-          <li><a href="https://community.ibm.com/community/user/ibmz-and-linuxone/groups/community-home/libr[…]yKey%253db0dae4a8-74eb-44ac-86c7-90f3cd32909a%26Action%3dnew" target="_blank" rel="noopener">Setting ISPF as the Default IDz/LPEX Editor</a></li>
+          <li><a href="https://community.ibm.com/community/user/ibmz-and-linuxone/viewdocument/setting-lpexispf-as-your-file-edit?CommunityKey=b0dae4a8-74eb-44ac-86c7-90f3cd32909a&tab=librarydocuments" target="_blank" rel="noopener">Setting ISPF as the Default IDz/LPEX Editor</a></li>
           <li><a href="https://community.ibm.com/community/user/ibmz-and-linuxone/viewdocument/disable-real-time-syntax-checking?CommunityKey=b0dae4a8-74eb-44ac-86c7-90f3cd32909a&amp;tab=librarydocuments" target="_blank" rel="noopener">Disable Real-Time Syntax Parsing:</a>
           <ul>
           <li>For working with incomplete programs or making trivial edits to your code</li>
@@ -1467,7 +1467,7 @@
           </div>
           <div data-widget="showhide" data-type="panel" class="ibm-show-hide ibm-widget-processed">
           <h2><a href="javascript:void();">&nbsp; Course Materials - Recordings and Enablement PDFs for Eclipse and ISPF Editing</a></h2>
-          <div class="ibm-container-body" style="padding-left: 40px; display: none;"><em><span style="font-size: 14pt">Note that all of the PDFs for IDz learning can be found under <a href="https://community.ibm.com/community/user/ibmz-and-linuxone/viewdocument/idz-adfz-remote-training-calendar?CommunityKey=b0dae4a8-74eb-44ac-86c7-90f3cd32909a&amp;tab=librarydocuments" target="_blank" rel="noopener"><strong>Setup</strong></a></span></em><br>
+          <div class="ibm-container-body" style="padding-left: 40px; display: none;"><em><span style="font-size: 14pt">Note that all of the PDFs for IDz learning can be found under <a href="https://ibm.github.io/mainframe-downloads/Training/idzrdz-remote-training.html" target="_blank" rel="noopener"><strong>Setup</strong></a></span></em><br>
           <ul>
           <li><a href="https://community.ibm.com/community/user/ibmz-and-linuxone/viewdocument/idzadfz-entry-level-product-educat?CommunityKey=b0dae4a8-74eb-44ac-86c7-90f3cd32909a&amp;tab=librarydocuments" target="_blank" rel="noopener"><strong>Module 1</strong> - IDz-Eclipse Introduction - Class Recording</a></li>
           <li><a href="https://community.ibm.com/community/user/ibmz-and-linuxone/viewdocument/idzadfz-entry-level-product-educat-1?CommunityKey=b0dae4a8-74eb-44ac-86c7-90f3cd32909a&amp;tab=librarydocuments" target="_blank" rel="noopener"><strong>Module 2</strong> - ISPF Editing Tools and Techniques - Class Recording</a></li>
@@ -1648,6 +1648,7 @@
             <div data-widget="showhide" data-type="panel" class="ibm-show-hide ibm-widget-processed">
               <div class="ibm-container-body">
               <ul>
+                <li><a href="https://www.ibm.com/support/pages/node/6332431" target="_blank" rel="noopener">How to preprocess a PLI program with dual NOT symbol in IDz?</a></li>
                 <li><a href="https://www.ibm.com/support/pages/node/6565325" target="_blank" rel="noopener">Getting started with IBM Developer for z/OS push-to-client</a></li>
                 <li><a href="https://community.ibm.com/community/user/ibmz-and-linuxone/blogs/olivier-gauneau1/2021/05/11/how-to-start-idz-client-faster" target="_blank" rel="noopener">How to start IDz client faster</a></li>
                 <li><a href="https://www.ibm.com/support/pages/node/6141381" target="_blank" rel="noopener">What are the general mustgather for IDz/RDz issues?</a></li>


### PR DESCRIPTION
Removed link to IBM Z DevOps Village Page
Added the "How to preprocess a PLI program with dual NOT symbol in IDz?" resource to the adfz-learning-resources page
Fixed broken links in adfz-learning-resources page