### PR TITLE
Added new resource

### DIFF
--- a/Training/adfz-learning-resources.html
+++ b/Training/adfz-learning-resources.html
@@ -1082,6 +1082,9 @@
                                 href="https://developer.ibm.com/blogs/use-the-right-tool-language-specific-editors-and-the-ispf-programmer/"
                                 target="_blank" rel="noopener">Use the right tool: Language-specific editors and the
                                 ISPF programmer</a></li>
+                            <li><a
+                                href="https://developer.ibm.com/tutorials/enable-persistent-hexadecimal-editing-capabilities-in-a-cobol-language-specific-editor/"
+                                target="_blank" rel="noopener">Enable persistent hexadecimal editing capabilities in a COBOL language-specific editor</a></li>
                           </ul>
                         </div>
                       </div>


### PR DESCRIPTION
Added the "Enable persistent hexadecimal editing capabilities in a COBOL language-specific editor" resource to the adfz-learning-resources page

Signed-off-by: John Nemec <john.nemec@ibm.com>