### PR TITLE
Removed new resource

### DIFF
--- a/DevOps_Acceleration_Program/resources.html
+++ b/DevOps_Acceleration_Program/resources.html
@@ -1477,35 +1477,7 @@
                         </td>
                       </tr>
                       -->
-                      <tr role="row">
-                        <td class="sorting_1">
-                          <a target="_blank"
-                            href="https://mediacenter.ibm.com/media/IMS+BMP+Testing+with+ZUnit+and+IDz/1_hniptg6s">
-                            IMS BMP Testing with ZUnit and IDz
-                          </a>
-                          <a href="javascript:void(0);" class="ibm-chevron-down-link abstract-toggle-button unselected"
-                            value="off" onclick="toggleAbstract(this)" >
-                          </a>
-                          <span class="abstract-text" style="display:none;">
-                            This video illustrates using the ZUnit capabilities in IDz to test a batch IMS BMP program. The ZUnit test will initially be created by capturing the batch program output. The demonstration will also include capturing Code Coverage information as well as how to modify the initial test case and add additional test cases.
-                          </span>
-                          <span class="ibm-hide keywords">demo_videos_resource</span>
-                          <span class="ibm-hide keywords">test_specialist</span>
-                          <span class="ibm-hide keywords">ZUnit_technology</span>
-                          <span class="ibm-hide keywords">Code_Coverage_technology</span>
-                          <span class="ibm-hide keywords">Testing_technology<span>
-                        </td>
-                        <td>
-                          <p>
-                            Demo Video
-                          </p>
-                        </td>
-                        <td>
-                          <p>
-                            2023-05
-                          </p>
-                        </td>
-                      </tr>
+                      
                       <tr role="row">
                         <td class="sorting_1">
                           <a target="_blank"


### PR DESCRIPTION
The new resource added yesterday is already included in a playlist listed in the resources page, and doesn't actually need to be included as its own resource, hence its removal