### PR TITLE
Course Renaming

### DIFF
--- a/Training/Training.html
+++ b/Training/Training.html
@@ -1295,7 +1295,7 @@
                       <div class="card-equal ibm-col-12-4 ibm-col-medium-12-6 ibm-col-sm-12-12">
                         <div class="ibm-card" style="height: 250px;">
                           <div class="ibm-card__content">
-                            <h3 class="ibm-h3">IBM Wazi Developer Fundamentals
+                            <h3 class="ibm-h3">Cloud native development with IBM Z and Cloud Modernization Stack Fundamentals
                             </h3>
                             <p>Self-paced learning</p>
                           </div>

--- a/Training/wazideveloper-self-paced-learning.html
+++ b/Training/wazideveloper-self-paced-learning.html
@@ -75,7 +75,7 @@
         },
       };
     </script>
-    <title>IBM Wazi Fundamentals</title>
+    <title>Cloud native development with IBM Z and Cloud Modernization Stack Fundamentals</title>
 
     <!-- This site is optimized with the Yoast SEO plugin v9.0.2 - https://yoast.com/wordpress/plugins/seo/ -->
     <link
@@ -86,11 +86,11 @@
     <meta property="og:type" content="article" />
     <meta
       property="og:title"
-      content="IBM Wazi Fundamentals"
+      content="Cloud native development with IBM Z and Cloud Modernization Stack Fundamentals"
     />
     <meta
       property="og:description"
-      content="IBM Wazi Fundamentals"
+      content="Cloud native development with IBM Z and Cloud Modernization Stack Fundamentals"
     />
     <meta
       property="og:url"
@@ -1252,13 +1252,13 @@
                     class="ibm-h1 ibm-textcolor-white-core ibm-padding-bottom-0 ibm-padding-top-1"
                     id="ibm-pagetitle-h1"
                   >
-                    <span>IBM Wazi Fundamentals</span>
+                    <span>Cloud native development with IBM Z and Cloud Modernization Stack Fundamentals</span>
                   </h1>
 
                   <p
                     class="ibm-h4 ibm-light ibm-textcolor-white-core ibm-padding-top-1 ibm-padding-bottom-1"
                   >
-                    <span>Accelerate your Journey to Cloud with IBM Wazi</span
+                    <span>Accelerate your Journey to Cloud with IBM Z and Cloud Modernization Stack</span
                     >
                   </p>
                 </div>
@@ -1308,7 +1308,7 @@
                     class="ibm-textcolor-default ibm-padding-top-0 ibm-padding-bottom-0"
                   >
                     <p>
-                        Digital credentials are the future and they are here for IBM Wazi. Digital credentials are transforming how IBM is engaging, recognizing and managing talent. The course is designed to provide the audience with a view into understanding the capabilities, benefits and usage of IBM Wazi.                    </p>
+                        Digital credentials are the future and they are here for Cloud native development with IBM Z and Cloud Modernization Stack. Digital credentials are transforming how IBM is engaging, recognizing and managing talent. The course is designed to provide the audience with a view into understanding the capabilities, benefits and usage of Cloud native development with IBM Z and Cloud Modernization Stack.                    </p>
                   </div>
                 </div>
                 <div class="ibm-col-12-2 ibm-col-medium-12-12 ibm-hide">
@@ -1379,7 +1379,7 @@
                       ><span>What it takes to earn this badge</span></strong
                     >
                     <p>
-                        Successful completion of the IBM Wazi online self paced course and clearing the badge quiz assessment.
+                        Successful completion of the Cloud native development with IBM Z and Cloud Modernization Stack Fundamentals online self paced course and clearing the badge quiz assessment.
                     <p>
                       Please access the following URL to launch the course:
                       <a
@@ -1399,7 +1399,7 @@
                     </p>
                     <strong><span>Badge Queries</span></strong>
                     <p>
-                        For questions about the IBM Wazi badge program, such as a missing or incorrect badge or how to earn the badge, contact
+                        For questions about the Cloud native development with IBM Z and Cloud Modernization Stack Fundamentals badge program, such as a missing or incorrect badge or how to earn the badge, contact
                       <a href="mailto:shabbirm@ca.ibm.com"
                         >shabbirm@ca.ibm.com</a
                       > or


### PR DESCRIPTION
The IBM Wazi Fundamentals course has been renamed to Cloud native development with IBM Z and Cloud Modernization Stack Fundamentals.