### PR TITLE
Updating course info

### DIFF
--- a/Training/Training.html
+++ b/Training/Training.html
@@ -1329,7 +1329,7 @@
                       <div class="card-equal ibm-col-12-4 ibm-col-medium-12-6 ibm-col-sm-12-12">
                         <div class="ibm-card" style="height: 250px;">
                           <div class="ibm-card__content">
-                            <h3 class="ibm-h3">IBM watsonx Code Assistant for Z Fundamentals <span style = "color: red;"><strong>(New)</strong></span>
+                            <h3 class="ibm-h3">IBM watsonx Code Assistant for Z Fundamentals 
                             </h3>
                             <p>Self-paced learning</p>
                           </div>

--- a/Training/dbb-self-paced-learning.html
+++ b/Training/dbb-self-paced-learning.html
@@ -1250,10 +1250,12 @@
                   <p
                     class="ibm-h4 ibm-light ibm-textcolor-white-core ibm-padding-top-1 ibm-padding-bottom-1"
                   >
-                    <span
-                      >Mainframe build in a DevOps pipeline with IBM Dependency
-                      Based Build</span
-                    >
+                    <span>
+                      Mainframe build in a DevOps pipeline with IBM Dependency
+                      Based Build
+                      <br>
+                      <strong style="color: red;">This course will be unavailable on Monday, March 3rd from 1pm EST to 5pm EST for updating.</strong>
+                    </span>
                   </p>
                 </div>
               </div>


### PR DESCRIPTION
Removed the "new" from the WCA4Z course.

Added warning about outage window for DBB course.

Signed-off-by: John Nemec <86624614+johnmnemec@users.noreply.github.com>