### PR TITLE
Archiving resources.html

### DIFF
--- a/DevOps_Acceleration_Program/devops-acceleration-program.html
+++ b/DevOps_Acceleration_Program/devops-acceleration-program.html
@@ -1231,8 +1231,8 @@
                   </p>
                   <div class="ibm-padding-top-1 ibm-padding-bottom-1">
                     <p class="ibm-padding-top-0 ibm-button-link ibm-btn-row">
-                      <a href="resources.html" class="ibm-btn-pri ibm-btn-white"
-                        >Resources</a
+                      <a href="https://ibm.github.io/z-devops-acceleration-program/" class="ibm-btn-pri ibm-btn-white"
+                        >Z DevOps Guide</a
                       >
                       <a href="#contactus" class="ibm-btn-sec ibm-btn-white"
                         >Contact</a
@@ -1672,14 +1672,14 @@
                                     style="height: 196.8px;"
                                   >
                                     <div class="ibm-card__content">
-                                      <h3>Resources</h3>
+                                      <h3>Z DevOps Guide</h3>
                                     </div>
                                     <div class="ibm-card__bottom">
                                       <p
                                         class="ibm-btn-row ibm-ind-link ibm-button-link"
                                       >
                                         <a
-                                          href="resources.html"
+                                          href="https://ibm.github.io/z-devops-acceleration-program/"
                                           class="ibm-btn-sec ibm-information-link ibm-btn-blue-50"
                                           tabindex="0"
                                           >More info</a

--- a/DevOps_Acceleration_Program/resources.html
+++ b/DevOps_Acceleration_Program/resources.html
@@ -1026,7 +1026,7 @@
           class="ibm-background-black-core ibm-leadspace-fluid ibm-no-border">
           <div id="ibm-leadspace-body" class="ibm-padding-top-2 ibm-padding-bottom-2">
             <div class="ibm-fluid ibm-padding-bottom-0">
-              <div class="ibm-col-medium-12-6 ibm-col-12-6 ">
+              <div class="ibm-col-medium-12-6 ">
                 <h1 class="ibm-h1 ibm-textcolor-white-core ibm-padding-bottom-0 ibm-padding-top-1"
                   id="ibm-pagetitle-h1">
                   <span>
@@ -1036,6 +1036,15 @@
                 <p class="ibm-h4 ibm-light ibm-textcolor-white-core ibm-padding-top-1 ibm-padding-bottom-1">
                   <span>
                     Start your DevOps Digital Transformation Journey
+                    <br>
+                    <br>
+                    <b>
+                      Note: This page is archived. The replacement for this page is the <a href="https://ibm.github.io/z-devops-acceleration-program/">IBM Z DevOps Guide.</a>
+                    
+                    <br>
+                    <br>
+                      If you found this page, please reach out to the <a href="mailto:dat@ibm.com">DevOps Acceleration Team</a>, and include how you found this page.
+                    </b>
                   </span>
                 </p>
               </div>


### PR DESCRIPTION
resources.html is being replaced by the Z DevOps Guide. We don't want to remove it completely for the sake of archiving, so all links to it are being changed to links to the Z DevOps Guide, and an archival messages is being added.