### PR TITLE
Renaming pages

### DIFF
--- a/DevOps_Acceleration_Program/dap.html
+++ b/DevOps_Acceleration_Program/dap.html
@@ -1,9 +1,10 @@
 <!DOCTYPE html>
+<!-- saved from url=(0073)https://developer.ibm.com/mainframe/products/devops-acceleration-program/ -->
 <html
   lang="en-US"
   prefix="og: http://ogp.me/ns#"
   style=""
-  class="applicationcache geolocation history postmessage svg websockets localstorage sessionstorage websqldatabase webworkers hashchange pointerevents canvas audio canvastext video webgl cssgradients multiplebgs opacity rgba inlinesvg hsla supports svgclippaths smil no-touchevents fontface generatedcontent textshadow cssanimations backgroundsize borderimage borderradius boxshadow csscolumns csscolumns-width csscolumns-span csscolumns-fill csscolumns-gap csscolumns-rule csscolumns-rulecolor csscolumns-rulestyle csscolumns-rulewidth csscolumns-breakbefore csscolumns-breakafter csscolumns-breakinside flexbox flexboxlegacy cssreflections csstransforms csstransforms3d csstransitions indexeddb indexeddb-deletedatabase js ibm-v18 ibm-cxtype-4g hires mac chrome chrome8 webkit webkit5 ibm-grid-xlarge"
+  class="applicationcache geolocation history postmessage svg websockets localstorage sessionstorage websqldatabase webworkers hashchange pointerevents canvas audio canvastext video webgl cssgradients multiplebgs opacity rgba inlinesvg hsla supports svgclippaths smil no-touchevents fontface no-generatedcontent textshadow cssanimations backgroundsize borderimage borderradius boxshadow csscolumns csscolumns-width csscolumns-span csscolumns-fill csscolumns-gap csscolumns-rule csscolumns-rulecolor csscolumns-rulestyle csscolumns-rulewidth csscolumns-breakbefore csscolumns-breakafter csscolumns-breakinside flexbox flexboxlegacy cssreflections csstransforms csstransforms3d csstransitions indexeddb indexeddb-deletedatabase js ibm-v18 ibm-cxtype-4g hires mac chrome chrome8 webkit webkit5 ibm-grid-xlarge"
 >
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
@@ -38,7 +39,7 @@
             effectiveDate: "2016-07-18",
             expiryDate: "2020-07-18",
             language: "en-US",
-            publishDate: "2019-11-26",
+            publishDate: "2019-08-06",
             publisher: "IBM Corporation",
             version: "v18",
             pageID: "",
@@ -75,27 +76,25 @@
         },
       };
     </script>
-    <title>IBM Application Discovery & Delivery Intelligence Essentials - Mainframe DEV</title>
+    <title>IBM DevOps Acceleration Program - Mainframe DEV</title>
 
     <!-- This site is optimized with the Yoast SEO plugin v9.0.2 - https://yoast.com/wordpress/plugins/seo/ -->
-    <link
-      rel="canonical"
-      href="https://developer.ibm.com/mainframe/products/devops-acceleration-program/training/dbb-self-paced-learning/"
+    <meta
+      name="description"
+      content="IBM’s DevOps Acceleration Program is a value-add program at no cost for clients who are getting started with the DevOps transformation journey."
     />
+    <link rel="canonical" href="#" />
     <meta property="og:locale" content="en_US" />
     <meta property="og:type" content="article" />
     <meta
       property="og:title"
-      content="IBM Application Discovery & Delivery Intelligence Essentials - Mainframe DEV"
+      content="IBM DevOps Acceleration Program - Mainframe DEV"
     />
     <meta
       property="og:description"
-      content="Home Products DevOps Acceleration Program IBM Application Discovery & Delivery Intelligence Essentials Static source analysis for application modernization with IBM ADDI Badge Overview Digital credentials are the future and they are here for Dependency Based Build (DBB). Digital credentials are transforming how IBM is engaging, recognising and managing talent. The course is designed to provide …"
+      content="IBM’s DevOps Acceleration Program is a value-add program at no cost for clients who are getting started with the DevOps transformation journey."
     />
-    <meta
-      property="og:url"
-      content="https://developer.ibm.com/mainframe/products/devops-acceleration-program/training/dbb-self-paced-learning/"
-    />
+    <meta property="og:url" content="#" />
     <meta property="og:site_name" content="Mainframe DEV" />
     <script type="application/ld+json">
       {
@@ -135,30 +134,6 @@
             "item": {
               "@id": "https:\/\/developer.ibm.com\/mainframe\/products\/devops-acceleration-program\/",
               "name": "DevOps Acceleration Program"
-            }
-          },
-          {
-            "@type": "ListItem",
-            "position": 4,
-            "item": {
-              "@id": "https:\/\/developer.ibm.com\/mainframe\/products\/devops-acceleration-program\/training\/",
-              "name": "Training"
-            }
-          },
-          {
-            "@type": "ListItem",
-            "position": 5,
-            "item": {
-              "@id": "https:\/\/developer.ibm.com\/mainframe\/products\/devops-acceleration-program\/training\/dbb-self-paced-learning\/",
-              "name": "IBM Dependency Based Build Fundamentals"
-            }
-          },
-          {
-            "@type": "ListItem",
-            "position": 6,
-            "item": {
-              "@id": "https:\/\/developer.ibm.com\/mainframe\/products\/devops-acceleration-program\/training\/addi-self-paced-learning\/",
-              "name": "IBM Application Discovery & Delivery Intelligence Essentials"
             }
           }
         ]
@@ -320,7 +295,7 @@
       })(window, document, window._wpemojiSettings);
     </script>
     <script
-      src="./dbb-self-paced-learning_files/wp-emoji-release.min.js"
+      src="./devops-acceleration-program_files/wp-emoji-release.min.js"
       type="text/javascript"
       defer=""
     ></script>
@@ -341,49 +316,49 @@
     <link
       rel="stylesheet"
       id="gdpr-css"
-      href="./dbb-self-paced-learning_files/gdpr-public.css"
+      href="./devops-acceleration-program_files/gdpr-public.css"
       type="text/css"
       media="all"
     />
     <link
       rel="stylesheet"
       id="tab-styles-css"
-      href="./dbb-self-paced-learning_files/tab-styles.css"
+      href="./devops-acceleration-program_files/tab-styles.css"
       type="text/css"
       media="all"
     />
     <link
       rel="stylesheet"
       id="home-v17-styles-css"
-      href="./dbb-self-paced-learning_files/home.css"
+      href="./devops-acceleration-program_files/home.css"
       type="text/css"
       media="all"
     />
     <link
       rel="stylesheet"
       id="rotatingtweets-css"
-      href="./dbb-self-paced-learning_files/style.css"
+      href="./devops-acceleration-program_files/style.css"
       type="text/css"
       media="all"
     />
     <link
       rel="stylesheet"
       id="dwboomer-style-css"
-      href="./dbb-self-paced-learning_files/style(1).css"
+      href="./devops-acceleration-program_files/style(1).css"
       type="text/css"
       media="all"
     />
     <link
       rel="stylesheet"
       id="dashicons-css"
-      href="./dbb-self-paced-learning_files/dashicons.min.css"
+      href="./devops-acceleration-program_files/dashicons.min.css"
       type="text/css"
       media="all"
     />
     <link
       rel="stylesheet"
       id="pagepost_css-css"
-      href="./dbb-self-paced-learning_files/pagepost.css"
+      href="./devops-acceleration-program_files/pagepost.css"
       type="text/css"
       media="all"
     />
@@ -524,30 +499,30 @@
     <link
       rel="stylesheet"
       id="pnext.utils-css"
-      href="./dbb-self-paced-learning_files/pnext.utils.css"
+      href="./devops-acceleration-program_files/pnext.utils.css"
       type="text/css"
       media="all"
     />
     <script
       type="text/javascript"
-      src="./dbb-self-paced-learning_files/www.js"
+      src="./devops-acceleration-program_files/www.js"
     ></script>
     <style></style>
     <script
       type="text/javascript"
-      src="./dbb-self-paced-learning_files/jquery.cycle.all.min.js"
+      src="./devops-acceleration-program_files/jquery.cycle.all.min.js"
     ></script>
     <script
       type="text/javascript"
-      src="./dbb-self-paced-learning_files/rotating_tweet.js"
+      src="./devops-acceleration-program_files/rotating_tweet.js"
     ></script>
     <script
       type="text/javascript"
-      src="./dbb-self-paced-learning_files/dyntabs.js"
+      src="./devops-acceleration-program_files/dyntabs.js"
     ></script>
     <script
       type="text/javascript"
-      src="./dbb-self-paced-learning_files/masonry.js"
+      src="./devops-acceleration-program_files/masonry.js"
     ></script>
     <script type="text/javascript">
       /* <![CDATA[ */
@@ -562,23 +537,23 @@
     </script>
     <script
       type="text/javascript"
-      src="./dbb-self-paced-learning_files/gdpr-public.js"
+      src="./devops-acceleration-program_files/gdpr-public.js"
     ></script>
     <script
       type="text/javascript"
-      src="./dbb-self-paced-learning_files/tab-dropdown.js"
+      src="./devops-acceleration-program_files/tab-dropdown.js"
     ></script>
     <script
       type="text/javascript"
-      src="./dbb-self-paced-learning_files/mainframe.js"
+      src="./devops-acceleration-program_files/mainframe.js"
     ></script>
     <script
       type="text/javascript"
-      src="./dbb-self-paced-learning_files/pnext.utils.js"
+      src="./devops-acceleration-program_files/pnext.utils.js"
     ></script>
     <script
       type="text/javascript"
-      src="./dbb-self-paced-learning_files/ida_stats.js"
+      src="./devops-acceleration-program_files/ida_stats.js"
     ></script>
     <link
       rel="https://api.w.org/"
@@ -596,24 +571,27 @@
       href="https://developer.ibm.com/mainframe/wp-includes/wlwmanifest.xml"
     />
     <meta name="generator" content="WordPress 4.9.9" />
-    <link rel="shortlink" href="https://developer.ibm.com/mainframe/?p=18535" />
+    <link rel="shortlink" href="https://developer.ibm.com/mainframe/?p=17162" />
     <link
       rel="alternate"
       type="application/json+oembed"
-      href="https://developer.ibm.com/mainframe/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fdeveloper.ibm.com%2Fmainframe%2Fproducts%2Fdevops-acceleration-program%2Ftraining%2Fdbb-self-paced-learning%2F"
+      href="https://developer.ibm.com/mainframe/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fdeveloper.ibm.com%2Fmainframe%2Fproducts%2Fdevops-acceleration-program%2F"
     />
     <link
       rel="alternate"
       type="text/xml+oembed"
-      href="https://developer.ibm.com/mainframe/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fdeveloper.ibm.com%2Fmainframe%2Fproducts%2Fdevops-acceleration-program%2Ftraining%2Fdbb-self-paced-learning%2F&amp;format=xml"
+      href="https://developer.ibm.com/mainframe/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fdeveloper.ibm.com%2Fmainframe%2Fproducts%2Fdevops-acceleration-program%2F&amp;format=xml"
     />
 
-    <link href="./dbb-self-paced-learning_files/www.css" rel="stylesheet" />
+    <link href="./devops-acceleration-program_files/www.css" rel="stylesheet" />
     <link
-      href="./dbb-self-paced-learning_files/grid-fluid.css"
+      href="./devops-acceleration-program_files/grid-fluid.css"
       rel="stylesheet"
     />
-    <link href="./dbb-self-paced-learning_files/tables.css" rel="stylesheet" />
+    <link
+      href="./devops-acceleration-program_files/tables.css"
+      rel="stylesheet"
+    />
 
     <script type="text/javascript">
       IBMCore.common.util.config.set({
@@ -639,12 +617,12 @@
       }
     </style>
     <style id="ibm-sitenav-menu-hidelinks">
-      @media screen and (max-width: 1075px) {
+      @media screen and (max-width: 1074.9875411987305px) {
         .ibm-sitenav-menu-container .ibm-sitenav-menu-list > ul > li {
           display: none;
         }
       }
-      @media screen and (min-width: 1076px) {
+      @media screen and (min-width: 1075.9875411987305px) {
         .ibm-mobilemenu-sitenavmenu > ul > li {
           display: none;
         }
@@ -654,8 +632,9 @@
 
   <body
     id="ibm-com"
-    class="page-template page-template-page-templates page-template-empty page-template-page-templatesempty-php page page-id-18535 page-child parent-pageid-16082 ibm-com ibm-type group-blog ibm-sitenav-menu"
+    class="page-template page-template-page-templates page-template-empty page-template-page-templatesempty-php page page-id-17162 page-parent page-child parent-pageid-34 ibm-com ibm-type group-blog ibm-sitenav-menu"
   >
+    
     <style>
       .code_p_announcement .code_content__wrap {
         background: #4178be;
@@ -693,11 +672,7 @@
     <div style="display:none">page-templates/empty.php</div>
     <!--div id="page" class="site"-->
     <div id="ibm-top" class="ibm-landing-page">
-      <a
-        class="skip-link screen-reader-text"
-        href="https://developer.ibm.com/mainframe/products/devops-acceleration-program/training/dbb-self-paced-learning/#main"
-        >Skip to content</a
-      >
+      <a class="skip-link screen-reader-text" href="#main">Skip to content</a>
 
       <!-- MASTHEAD_BEGIN -->
       <div
@@ -731,11 +706,7 @@
         <p class="ibm-hide" id="ibm-burgermenu-a11y">Site navigation</p>
         <div class="ibm-mobilemenu-close">
           <p class="ibm-icononly ibm-fright ibm-ind-link ibm-nospacing">
-            <a
-              class="ibm-close-link"
-              href="https://developer.ibm.com/mainframe/products/devops-acceleration-program/training/dbb-self-paced-learning/?lnk=hm#"
-              >Close</a
-            >
+            <a class="ibm-close-link" href="#">Close</a>
           </p>
         </div>
         <div class="ibm-mobilemenu-section ibm-mobilemenu-sitenavmenu">
@@ -765,13 +736,9 @@
             </li>
             <li
               id="menu-item-16086"
-              class="menu-item menu-item-type-post_type menu-item-object-page current-page-ancestor menu-item-16086"
+              class="menu-item menu-item-type-post_type menu-item-object-page menu-item-16086"
             >
-              <a
-                href="https://developer.ibm.com/mainframe/products/devops-acceleration-program/training/?lnk=hm"
-                tabindex="-1"
-                >Training</a
-              >
+              <a href="" tabindex="-1">Training</a>
             </li>
             <li
               id="menu-item-14411"
@@ -1158,7 +1125,7 @@
           </ul>
         </div>
       </div>
-      <div class="ibm-mhplaceholder ibm-hide"></div>
+      <div class="ibm-hide ibm-mhplaceholder"></div>
       <!-- MASTHEAD_END -->
       <div id="ibm-content-wrapper">
         <header role="banner" aria-labelledby="ibm-pagetitle-h1">
@@ -1181,9 +1148,9 @@
 
                 <li
                   id="menu-item-16086"
-                  class="menu-item menu-item-type-post_type menu-item-object-page current-menu-item page_item page-item-16082 current_page_item menu-item-16086"
+                  class="menu-item menu-item-type-post_type menu-item-object-page page_item page-item-16082 menu-item-16086"
                 >
-                  <a href="Training.html" tabindex="-1">Training</a>
+                  <a href="../Training/Training.html" tabindex="-1">Training</a>
                 </li>
 
                 <li
@@ -1216,13 +1183,12 @@
                     </li>
                   </ul>
                 </li>
+
                 <li
                   id="menu-item-devops-acceleration"
-                  class="menu-item menu-item-type-post_type menu-item-object-page page_item"
+                  class="menu-item menu-item-type-post_type menu-item-object-page page_item current_page_item"
                 >
-                  <a
-                    href="../DevOps_Acceleration_Program/devops-acceleration-program.html"
-                    tabindex="-1"
+                  <a href="dap.html" tabindex="-1"
                     >DevOps Acceleration Program</a
                   >
                 </li>
@@ -1238,6 +1204,8 @@
         </style>
         <div id="content" class="site-content">
           <!--Because the_content() works only inside a WP Loop -->
+          <!-- Lead space carousel start -->
+
           <div
             id="ibm-leadspace-head"
             style="background-image:url(//1.cms.s81c.com/sites/default/files/2018-06-13/image-leadspace-Z-for-system-integrity-2000x500.jpg); background-repeat:no-repeat; background-size: cover; background-position: center;"
@@ -1253,15 +1221,24 @@
                     class="ibm-h1 ibm-textcolor-white-core ibm-padding-bottom-0 ibm-padding-top-1"
                     id="ibm-pagetitle-h1"
                   >
-                    <span>DevOps Distance Learning Program</span>
+                    <span>DevOps Acceleration Program</span>
                   </h1>
 
                   <p
                     class="ibm-h4 ibm-light ibm-textcolor-white-core ibm-padding-top-1 ibm-padding-bottom-1"
                   >
-                    <span>Instructor Led Training</span
-                    >
+                    <span>Start your DevOps Transformation Journey</span>
                   </p>
+                  <div class="ibm-padding-top-1 ibm-padding-bottom-1">
+                    <p class="ibm-padding-top-0 ibm-button-link ibm-btn-row">
+                      <a href="https://ibm.github.io/z-devops-acceleration-program/" class="ibm-btn-pri ibm-btn-white"
+                        >Z DevOps Guide</a
+                      >
+                      <a href="#contactus" class="ibm-btn-sec ibm-btn-white"
+                        >Contact</a
+                      >
+                    </p>
+                  </div>
                 </div>
               </div>
             </div>
@@ -1274,197 +1251,527 @@
                   <h2
                     class="ibm-h2 ibm-padding-top-0 ibm-padding-bottom-1 ibm-textcolor-blue-50"
                   >
-                  Course Calendar
-                  </h2>
-                </div>
-                <div
-                  class="ibm-col-12-7 ibm-col-medium-12-12"
-                  style="padding-top: 1rem;"
-                >
-                  <a
-                    href="https://ibm.github.io/mainframe-downloads/Training/idzrdz-remote-training.html"
-                    >https://ibm.github.io/mainframe-downloads/Training/idzrdz-remote-training.html</a
-                  >
-                </div>
-                <div class="ibm-col-12-2 ibm-col-medium-12-12 ibm-hide">
-                  <img
-                    src="./dbb-self-paced-learning_files/idzbadge.png"
-                    alt="DBB Badge"
-                  />
-                </div>
-              </div>
-            </div>
-
-            <div class="ibm-fluid ibm-padding-bottom-r1 ibm-padding-top-r1">
-              <div>
-                <div class="ibm-col-12-3 ibm-col-medium-12-12">
-                  <h2
-                    class="ibm-h2 ibm-padding-top-0 ibm-padding-bottom-1 ibm-textcolor-blue-50"
-                  >
-                    Badge Overview
-                  </h2>
-                </div>
-                <div class="ibm-col-12-7 ibm-col-medium-12-12 ">
-                  <div
-                    class="ibm-textcolor-default ibm-padding-top-0 ibm-padding-bottom-0"
-                  >
-                    <p>
-                        Digital Badges are shaping the future of professional credentials, and now they are here for 
-                        <strong>Application Delivery Foundation for z/OS (ADFz)</strong> 
-                        through the 
-                        <a href="https://ibm.github.io/mainframe-downloads/Training/idzrdz-remote-training.html">
-                            ADFz Distance Learning Curriculum
-                        </a>
-                        .
-                    </p>
-                  </div>
-                </div>
-                <div class="ibm-col-12-2 ibm-col-medium-12-12 ibm-hide">
-                  <img
-                    src="./dbb-self-paced-learning_files/idzbadge.png"
-                    alt="DBB Badge"
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div class="ibm-background-neutral-white-30">
-            <div class="ibm-fluid ibm-padding-bottom-r1 ibm-padding-top-r1">
-              <div>
-                <div class="ibm-col-12-3 ibm-col-medium-12-12">
-                  <h2
-                    class="ibm-h2 ibm-padding-top-0 ibm-padding-bottom-1 ibm-textcolor-blue-50"
-                  >
-                    Badge Description
+                    DevOps Acceleration Program
                   </h2>
                 </div>
                 <div class="ibm-col-12-9 ibm-col-medium-12-12 ">
                   <div
                     class="ibm-textcolor-default ibm-padding-top-0 ibm-padding-bottom-0"
                   >
-                    <p>
-                        The badge earner understands and can articulate foundational knowledge of 
-                        <a href="https://www.ibm.com/products/app-delivery-foundation-for-zos">
-                            IBM Application Delivery Foundation for z/OS (ADFz)
-                        </a>
-                        . Through completion of workshops and associated labs, the individual has gained 
-                        knowledge of the following: Mastering elementary Eclipse terms & concepts; 
-                        Navigating seamlessly through the product; Customizing preferences, views & perspectives; 
-                        Analyzing, editing & debugging programs; Coding & testing DB2/SQL statements; 
-                        and Managing Jobs & remote files & data sets.
-                    </p>
-                    <p>
-                        This program is a remote deep dive/technical training offering from IBM ADFz enablement 
-                        specialists. It equips you with the skills for enterprise-level production work with ADFz. 
-                        The feedback from clients on this training program is overwhelmingly positive, and the 
-                        added bonus is that you now get to authenticate your ADFz cred with a Digital Badge.
-                    </p>
-                    <p>
-                        Upon completion of this course, students will be able to perform the following using IDz:
-                    </p>
-                    <ul>
-                      <li>
-                        Module 1 – The IDz Workbench and introduction to Eclipse for ISPF Developers
-                      </li>
-                      <li>
-                        Module 2 – Editing Program Source
-                      </li>
-                      <li>
-                        Module 3 – Analyzing COBOL Programs
-                      </li>
-                      <li>
-                        Module 4 – Introduction to IDz Remote Systems’ Features
-                      </li>
-                      <li>
-                        Module 5 – Dataset Access and Organization
-                      </li>
-                      <li>
-                        Module 6 – ISPF 3.x Options, Batch Job Submission &amp; Management
-                      </li>
-                      <li>
-                        Module 7 – Git usage in IDz
-                      </li>
-                      <li>
-                        Module 8 – The DB2 and SQL Data Tools
-                      </li>
-                      <li>
-                        Module 9 – Debugging z/OS COBOL Applications using IDz
-                      </li>
-                    </ul>
+                    <!-- <p>IBM’s DevOps Acceleration Program is <strong>a value-add program</strong> at <strong>no cost</strong> for clients who are getting
+                        started with the DevOps transformation journey. Whether you're transforming in stages or
+                        adopting a big bang approach, IBM's DevOps Acceleration
+                        Program will partner with you to succeed. </p>
 
-                    <strong
-                      ><span>What it takes to earn this badge</span></strong
-                    >
+                    <p>Our structured approach towards transformation begins with a Value stream assessment. A workshop
+                        to infuse proven practices, lessons learned and as a result provides with a pragmatic
+                        transformation roadmap. </p>
+
+                    <p>The Program also includes free world class training focused on equipping you with the required skills to
+                        make a DevOps transformation successful. </p>
+
+                    <p>The Program extends beyond the roadmap and training to add deployment and adoption services at no cost for the first representative migration.</p>
+
+                    <p>Click the following links to learn more.</p> -->
                     <p>
-                        Successful completion of the ADFz Distance Learning Curriculum, consisting of 9 modules, including the following:
+                      IBM strongly believes that DevOps transformations are
+                      anything but plug-and-play; each enterprise brings with it
+                      its own culture, IT infrastructure, and mission.
+                      Transformation requires an absolute paradigm shift in your
+                      organization. It can be tough, we get it. Perhaps many
+                      enterprises wish to begin their transformation today but
+                      find themselves always putting it off till tomorrow.
+                    </p>
+                    <p>
+                      We wanted to create a better way of bridging the gap
+                      between the intention to move towards a DevOps model and
+                      the successful transformation of such a move. That's why
+                      we've created the DevOps Acceleration Program (DAP). A
+                      value-add early adoption program designed to partner with
+                      clients during four distinct stages that we believe are
+                      necessary for any DevOps transformation:
                     </p>
                     <ul>
-                        <li>
-                            Content/Concepts & Facilities: Presentation + Slideware
-                        </li>
-                        <li>
-                            Hands-on Labs and Workshops
-                        </li>
-                        <li>
-                            Application of all ADFz/IDz skills and techniques to production application development work
-                        </li>
+                      <li>Value Stream Assessment</li>
+                      <li>Training</li>
+                      <li>Deployment</li>
+                      <li>Adoption</li>
                     </ul>
-                    <p>
-                        You will receive your badge within 10 business days of completing the training curriculum. 
-                        This badge can be obtained by any IBM employee or non-IBM employee.
-                    </p>
-                    <strong
-                      ><span
-                        >More about the IBM Digital Badge program</span
-                      ></strong
+                  </div>
+                </div>
+                <div class="ibm-col-12-3 ibm-col-medium-12-5 "></div>
+              </div>
+            </div>
+          </div>
+
+          <div
+            id="pillars"
+            class="ibm-band ibm-background-gray-90 ibm-textcolor-white-core"
+          >
+            <div class="ibm-fluid ibm-padding-bottom-r1 ibm-padding-top-r1">
+              <div>
+                <div class="ibm-col-12-3 ibm-col-medium-12-12">
+                  <h2
+                    class="ibm-h2 ibm-padding-top-0 ibm-padding-bottom-1 ibm-textcolor-blue-30"
+                  >
+                    DevOps Transformation Journey
+                  </h2>
+                </div>
+                <div class="ibm-col-12-9 ibm-col-medium-12-12 ">
+                  <div
+                    class="ibm-textcolor-default ibm-padding-top-0 ibm-padding-bottom-0"
+                  >
+                    <div
+                      class="ibm-fluid svg-container ibm-seamless ibm-widget-processed ibm-sameheight-processed"
+                      data-items=".ibm-card"
+                      data-widget="setsameheight"
                     >
+                      <div
+                        class="ibm-col-12-3 ibm-col-medium-12-6 ibm-col-sm-12-12"
+                      >
+                        <div
+                          class="ibm-card ibm-no-border ibm-background-gray-90 ibm-center ibm-margin-bottom-0"
+                          style="height: 293.725px;"
+                        >
+                          <div class="ibm-card__image">
+                            <svg
+                              xmlns="http://www.w3.org/2000/svg"
+                              viewBox="0 0 32 32"
+                            >
+                              <path d="M4 2H2v27a1 1 0 0 0 1 1h27v-2H4z"></path>
+                              <path
+                                d="M30 9h-7v2h3.59L19 18.59l-4.29-4.3a1 1 0 0 0-1.42 0L6 21.59 7.41 23 14 16.41l4.29 4.3a1 1 0 0 0 1.42 0l8.29-8.3V16h2z"
+                              ></path>
+                            </svg>
+                          </div>
+                          <div class="ibm-card__content ibm-textcolor-blue-30">
+                            <h3 class="ibm-h3">Assessment</h3>
+                            <p class="ibm-padding-top-1 ibm-button-link">
+                              <a
+                                href="assessment.html"
+                                class="ibm-btn-sec ibm-btn-white"
+                                >Learn more</a
+                              >
+                            </p>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        class="ibm-col-12-3 ibm-col-medium-12-6 ibm-col-sm-12-12"
+                      >
+                        <div
+                          class="ibm-card ibm-no-border ibm-background-gray-90 ibm-center ibm-margin-bottom-0"
+                          style="height: 293.725px;"
+                        >
+                          <div class="ibm-card__image">
+                            <svg
+                              xmlns="http://www.w3.org/2000/svg"
+                              viewBox="0 0 32 32"
+                            >
+                              <path
+                                d="M15 10h2v8h-2zm5 4h2v4h-2zm-10-2h2v6h-2z"
+                              ></path>
+                              <path
+                                d="M25 4h-8V2h-2v2H7a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h8v6h-4v2h10v-2h-4v-6h8a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2zm0 16H7V6h18z"
+                              ></path>
+                            </svg>
+                          </div>
+                          <div class="ibm-card__content ibm-textcolor-blue-30">
+                            <h3 class="ibm-h3">Training</h3>
+                            <p class="ibm-padding-top-1 ibm-button-link">
+                              <a
+                                href="../Training/Training.html"
+                                class="ibm-btn-sec ibm-btn-white"
+                                >Learn more</a
+                              >
+                            </p>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        class="ibm-col-12-3 ibm-col-medium-12-6 ibm-col-sm-12-12"
+                      >
+                        <div
+                          class="ibm-card ibm-no-border ibm-background-gray-90 ibm-center ibm-margin-bottom-0"
+                          style="height: 293.725px;"
+                        >
+                          <div class="ibm-card__image">
+                            <svg
+                              xmlns="http://www.w3.org/2000/svg"
+                              viewBox="0 0 32 32"
+                            >
+                              <path
+                                d="M7.288 23.292l7.997-7.997 1.414 1.414-7.997 7.997z"
+                              ></path>
+                              <path
+                                d="M17 30a1 1 0 0 1-.37-.07 1 1 0 0 1-.62-.79l-1-7 2-.28.75 5.27L21 24.52V17a1 1 0 0 1 .29-.71l4.07-4.07A8.94 8.94 0 0 0 28 5.86V4h-1.86a8.94 8.94 0 0 0-6.36 2.64l-4.07 4.07A1 1 0 0 1 15 11H7.48l-2.61 3.26 5.27.75-.28 2-7-1a1 1 0 0 1-.79-.62 1 1 0 0 1 .15-1l4-5A1 1 0 0 1 7 9h7.59l3.77-3.78A10.92 10.92 0 0 1 26.14 2H28a2 2 0 0 1 2 2v1.86a10.92 10.92 0 0 1-3.22 7.78L23 17.41V25a1 1 0 0 1-.38.78l-5 4A1 1 0 0 1 17 30z"
+                              ></path>
+                            </svg>
+                          </div>
+                          <div class="ibm-card__content ibm-textcolor-blue-30">
+                            <h3 class="ibm-h3">Deployment</h3>
+                            <p class="ibm-padding-top-1 ibm-button-link">
+                              <a
+                                href="deployment.html"
+                                class="ibm-btn-sec ibm-btn-white"
+                                >Learn more</a
+                              >
+                            </p>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        class="ibm-col-12-3 ibm-col-medium-12-6 ibm-col-sm-12-12"
+                      >
+                        <div
+                          class="ibm-card ibm-no-border ibm-background-gray-90 ibm-center ibm-margin-bottom-0"
+                          style="height: 293.725px;"
+                        >
+                          <div class="ibm-card__image">
+                            <svg
+                              xmlns="http://www.w3.org/2000/svg"
+                              viewBox="0 0 32 32"
+                            >
+                              <path
+                                d="M26 2H6a2 2 0 0 0-2 2v4a2 2 0 0 0 2 2h9v6.17l-2.59-2.58L11 15l5 5 5-5-1.41-1.41L17 16.17V10h9a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2zm0 6H6V4h20z"
+                              ></path>
+                              <circle cx="9" cy="6" r="1"></circle>
+                              <path
+                                d="M9 5a1 1 0 1 0 1 1 1 1 0 0 0-1-1zm17 19v4H6v-4h20m0-2H6a2 2 0 0 0-2 2v4a2 2 0 0 0 2 2h20a2 2 0 0 0 2-2v-4a2 2 0 0 0-2-2z"
+                              ></path>
+                              <circle cx="23" cy="26" r="1"></circle>
+                              <path
+                                d="M23 25a1 1 0 1 0 1 1 1 1 0 0 0-1-1z"
+                              ></path>
+                            </svg>
+                          </div>
+                          <div class="ibm-card__content ibm-textcolor-blue-30">
+                            <h3 class="ibm-h3">Adoption</h3>
+                            <p class="ibm-padding-top-1 ibm-button-link">
+                              <a
+                                href="adoption.html"
+                                class="ibm-btn-sec ibm-btn-white"
+                                >Learn more</a
+                              >
+                            </p>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <!-- 
+<div class="ibm-band ibm-background-neutral-white-20 ibm-textcolor-default">
+    <div class="ibm-fluid ibm-padding-bottom-r1 ibm-padding-top-r1">
+        <div>
+            <div class="ibm-col-12-3 ibm-col-medium-12-12">
+                <h2 class="ibm-h2 ibm-padding-top-0 ibm-padding-bottom-1 ibm-textcolor-blue-60">Value Stream Analysis
+                </h2>
+            </div>
+            <div class="ibm-col-12-9 ibm-col-medium-12-12 ">
+                <div class="ibm-textcolor-default ibm-padding-top-0 ibm-padding-bottom-0">
+                    <h4 class="ibm-h4">Engagement model</h4>
+                    <ul>
+                        <li>Initial recommendations</li>
+                        <li>30-day iteration(s)/MVP</li>
+                        <li>Yearly/6-month recalbration</li>
+                        <li>Pre-deployment consultation</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+</div> -->
+
+          <div
+            style="display:none !important;"
+            class="ibm-band ibm-background-blue-80 ibm-textcolor-white-core"
+          >
+            <div class="ibm-fluid ibm-padding-bottom-r1 ibm-padding-top-1">
+              <div>
+                <div class="ibm-col-12-3 ibm-col-medium-12-12 ">
+                  <h2
+                    class="ibm-h2 ibm-padding-top-1 ibm-padding-bottom-1 ibm-textcolor-white-core"
+                  >
+                    Our client testimonials
+                  </h2>
+                </div>
+                <div class="ibm-col-12-9 ibm-col-medium-12-12 ">
+                  <div
+                    class="ibm-textcolor-white-core ibm-padding-top-1 ibm-padding-bottom-0 ibm-pull-quote ibm-h3 "
+                  >
+                    <div
+                      data-widget="carousel"
+                      data-autoplay="true"
+                      class="ibm-carousel__controls--light slick-initialized slick-slider ibm-widget-processed"
+                      data-infinite="true"
+                    >
+                      <div aria-live="polite" class="slick-list draggable">
+                        <div
+                          class="slick-track"
+                          style="opacity: 1; width: 0px; transform: translate3d(0px, 0px, 0px);"
+                          role="listbox"
+                          aria-label="Carousel"
+                        >
+                          <div
+                            class="ibm-columns content-area-restricted ibm-alternate-background slick-slide slick-current slick-active"
+                            data-slick-index="0"
+                            aria-hidden="false"
+                            style="width: 0px;"
+                            tabindex="-1"
+                            role="option"
+                            aria-describedby="slick-slide00"
+                            id="navigation00"
+                          >
+                            <blockquote>
+                              <p>
+                                <em>
+                                  <span class="ibm-pull-quote-open">“</span>
+                                  <span
+                                    >When we talk to clients, certainly security
+                                    and trust are the two biggest things. [With
+                                    IBM Z] there has been absolutely no security
+                                    breach over the past 15 years.</span
+                                  >
+                                  <span class="ibm-pull-quote-close">”</span>
+                                </em>
+                              </p>
+                              <p class="ibm-padding-bottom-0">
+                                —Addie Buissinne, Director of Financial
+                                Solutions, Emid
+                              </p>
+                            </blockquote>
+                          </div>
+                        </div>
+                      </div>
+                      <!-- Slide 2-->
+                      <!-- 
+                        <div class="ibm-columns content-area-restricted ibm-alternate-background">
+                            <blockquote>
+                                <p>
+                                    <em>
+                                        <span class="ibm-pull-quote-open">“</span>
+                                        <span>When we talk to clients, certainly security and trust are the two biggest
+                                            things. [With IBM Z] there has been absolutely no security breach over the
+                                            past 15 years.</span>
+                                        <span class="ibm-pull-quote-close">”</span>
+                                    </em>
+                                </p>
+                                <p class="ibm-padding-bottom-0">
+                                    —Addie Buissinne, Director of Financial Solutions, Emid
+                                </p>
+                            </blockquote>
+                        </div> -->
+                      <div class="ibm-carousel-controls">
+                        <div class="ibm-cc-prev"></div>
+                        <div
+                          class="ibm-cc-middle"
+                          aria-label="Carousel controls"
+                        ></div>
+                        <div class="ibm-cc-next"></div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          
+          <!-- 
+          <div class="ibm-band ibm-background-white-core ibm-textcolor-default">
+            <div class="ibm-fluid ibm-padding-bottom-r1 ibm-padding-top-1">
+              <div class="ibm-col-12-3 ibm-col-medium-12-12">
+                <h2 class="ibm-h2 ibm-padding-top-1 ibm-padding-bottom-1 ibm-textcolor-blue-50">
+                News, Updates &amp; Resources
+              </h2>
+            </div>
+                <div class="ibm-col-12-9 ibm-col-medium-12-12 ">
+                  <div
+                    class="ibm-textcolor-default ibm-padding-top-1 ibm-padding-bottom-0 ibm-widget-processed ibm-sameheight-processed"
+                    data-widget="setsameheight"
+                    data-items=".ibm-card"
+                  >
+                    <div
+                      data-widget="carousel"
+                      data-autoplay="false"
+                      data-infinite="true"
+                      class="slick-initialized slick-slider ibm-widget-processed"
+                    >
+                      <Slide 1> 
+                      <div aria-live="polite" class="slick-list draggable">
+                        <div
+                          class="slick-track"
+                          style="opacity: 1; width: 973px; transform: translate3d(0px, 0px, 0px);"
+                          role="listbox"
+                          aria-label="Carousel"
+                        >
+                          <div
+                            class="ibm-columns content-area-restricted slick-slide slick-current slick-active"
+                            data-slick-index="0"
+                            aria-hidden="false"
+                            style="width: 973px;"
+                            tabindex="-1"
+                            role="option"
+                            aria-describedby="slick-slide10"
+                            id="navigation10"
+                          >
+                            <div class="ibm-col-4-3 ibm-center-block">
+                              <div class="ibm-columns">
+                                
+                                <div class="ibm-col-12-3 ibm-col-medium-12-12">
+                                  <div
+                                    class="ibm-card dl-card"
+                                    style="height: 196.8px;"
+                                  >
+                                    <div class="ibm-card__content">
+                                      <h3>New Training Sessions Added</h3>
+                                    </div>
+                                    <div class="ibm-card__bottom">
+                                      <p
+                                        class="ibm-btn-row ibm-ind-link ibm-button-link"
+                                      >
+                                        <a
+                                          href="../Training/idzrdz-remote-training.html"
+                                          class="ibm-btn-sec ibm-information-link ibm-btn-blue-50"
+                                          tabindex="0"
+                                          >More info</a
+                                        >
+                                      </p>
+                                    </div>
+                                  </div>
+                                </div>
+
+                                <div class="ibm-col-12-3 ibm-col-medium-12-12">
+                                  <div
+                                    class="ibm-card dl-card"
+                                    style="height: 196.8px;"
+                                  >
+                                    <div class="ibm-card__content">
+                                      <h3>Z DevOps Guide</h3>
+                                    </div>
+                                    <div class="ibm-card__bottom">
+                                      <p
+                                        class="ibm-btn-row ibm-ind-link ibm-button-link"
+                                      >
+                                        <a
+                                          href="https://ibm.github.io/z-devops-acceleration-program/"
+                                          class="ibm-btn-sec ibm-information-link ibm-btn-blue-50"
+                                          tabindex="0"
+                                          >More info</a
+                                        >
+                                      </p>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+
+                      <Slide 2>
+
+                    
+                        <div class="ibm-columns content-area-restricted">
+
+                            <div class="ibm-col-4-3 ibm-center-block">
+                                <div class="ibm-columns">
+
+
+                                    <div class="ibm-col-4-1 ibm-col-medium-4-3">
+                                        <div class="ibm-card dl-card" style="height: 347px;">
+                                            <div class="ibm-card__content">
+                                                <h3>News item 4
+                                                </h3>
+                                                <p>Curabitur ullamcorper a mi a eleifend. Ut a justo purus. Praesent
+                                                    laoreet ex nec nibh feugiat, non venenatis massa ornare.</p>
+                                            </div>
+                                            <div class="ibm-card__bottom">
+                                                <p class="ibm-btn-row ibm-ind-link ibm-button-link">
+                                                    <a href="#" class="ibm-btn-sec ibm-information-link ibm-btn-blue-50"
+                                                        tabindex="-1">More info</a>
+                                                </p>
+                                            </div>
+                                        </div>
+                                    </div>
+
+          
+                                    <div class="ibm-col-4-1 ibm-col-medium-4-3">
+                                        <div class="ibm-card dl-card" style="height: 347px;">
+                                            <div class="ibm-card__content">
+                                                <h3>News item 5
+                                                </h3>
+                                                <p>Nullam nec lacus vel turpis cursus aliquam a quis arcu. Proin sit
+                                                    amet venenatis arcu. Quisque porttitor iaculis diam varius
+                                                    dignissim. </p>
+                                            </div>
+                                            <div class="ibm-card__bottom">
+                                                <p class="ibm-btn-row ibm-ind-link ibm-button-link">
+                                                    <a href="" class="ibm-btn-sec ibm-information-link ibm-btn-blue-50"
+                                                        tabindex="-1">More info</a>
+                                                </p>
+                                            </div>
+                                        </div>
+                                    </div>
+
+
+                                    <div class="ibm-col-4-1 ibm-col-medium-4-3">
+                                        <div class="ibm-card dl-card" style="height: 347px;">
+                                            <div class="ibm-card__content">
+                                                <h3>News item 6</h3>
+                                                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam et
+                                                    luctus eros, vitae tempor turpis. </p>
+                                            </div>
+                                            <div class="ibm-card__bottom">
+                                                <p class="ibm-btn-row ibm-ind-link ibm-button-link">
+                                                    <a target="_blank" href=""
+                                                        class="ibm-btn-sec ibm-information-link ibm-btn-blue-50"
+                                                        tabindex="-1">More info</a>
+                                                </p>
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                </div>
+                            </div>
+                        </div>
+                      <div class="ibm-carousel-controls">
+                        <div class="ibm-cc-prev"></div>
+                        <div
+                          class="ibm-cc-middle"
+                          aria-label="Carousel controls"
+                        ></div>
+                        <div class="ibm-cc-next"></div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            -->
+          
+          <div class="ibm-band ibm-band ibm-background-cool-gray-80 ibm-textcolor-white-core">
+            <div class="ibm-fluid ibm-padding-bottom-r1 ibm-padding-top-1">
+              <div>
+                <div class="ibm-col-12-3 ibm-col-medium-12-12 ">
+                  <h2 id="contactus" class="ibm-h2 ibm-padding-top-1 ibm-padding-bottom-1 ibm-textcolor-white-core">
+                    Contact us
+                  </h2>
+                </div>
+                <div class="ibm-col-12-9 ibm-col-medium-12-12 ">
+                  <div class="ibm-textcolor-white-core ibm-padding-top-1 ibm-padding-bottom-0 ibm-pull-quote ibm-h3 ">
                     <p>
-                        IBM has established a Digital Badge Program to recognize our employees' significant achievements 
-                        and skills attainment. IBM credentials are recognized, respected and valued globally in the IT 
-                        industry. This program will enable you to easily and quickly share verified proof of your 
-                        achievement both within IBM and externally. Where applicable, your IBM credentials will be 
-                        represented by a digital image that contains verified metadata describing your qualifications 
-                        and the rigorous process necessary to earn them.
-                    </p>
-                    <strong><span>Badge Queries</span></strong>
-                    <p>
-                        For questions about the IDz Basics badge program, such as a missing or incorrect badge or how 
-                        to earn the badge, contact
-                        <a href="mailto:dat@ibm.com"
-                        >dat@ibm.com</a>                            >
-                    </p>
-                    <p>
-                      Credly Support: For questions related to your Credly badge earner account and profile, as well as 
-                      issues related to claiming your badge after receiving a notification, go to support.credly.com.
-                    </p>
-                    <p>
-                      For Frequently Asked Questions about the IBM Digital Badge
-                      Program, click
-                      <a
-                        href="https://www-03.ibm.com/services/learning/ites.wss/zz-en?pageType=page&amp;c=P430723G05904L37"
-                        >here</a
-                      >.
-                    </p>
-                    <strong><span>Badge Privacy Statement</span></strong>
-                    <p>
-                      NOTICE: IBM leverages the services of Credly, a 3rd party data processor authorized 
-                      by IBM and located in the United States, to assist in the administration of 
-                      the IBM Digital Badge program. In order to issue you an IBM Digital Badge, your 
-                      personal information (name, email address, and badge earned) will be shared 
-                      with Credly. You will receive an email notification from Credly with instructions 
-                      for claiming the badge. Your personal information is used to issue your badge 
-                      and for program reporting and operational purposes. IBM may share the personal information
-                      collected with IBM subsidiaries and third parties globally. It will be handled 
-                      in a manner consistent with IBM privacy practices.The IBM Privacy Statement can be viewed 
-                      here: 
-                      <a href="https://www.ibm.com/privacy/us/en/">
-                        https://www.ibm.com/privacy/us/en/
-                      </a>
-                      IBM employees can view the IBM Internal Privacy Statement here: 
-                      <a href="https://w3.ibm.com/w3publisher/w3-privacy-notice">
-                        https://w3.ibm.com/w3publisher/w3-privacy-notice
-                      </a>.
+                      If you have any questions or inquiries regarding the
+                      DevOps Acceleration Program, please feel free to contact
+                      the
+                      <strong>
+                        <a style="color:white;text-decoration:underline;" href="mailto:dat@ibm.com">
+                          DevOps Acceleration Team
+                        </a>
+                      </strong>
                     </p>
                   </div>
                 </div>
@@ -1483,7 +1790,7 @@
         <a
           class="ibm-nospacing ibm-top-link"
           aria-label="Back to top"
-          href="https://developer.ibm.com/mainframe/products/devops-acceleration-program/training/dbb-self-paced-learning/#top"
+          href="#top"
           tabindex="0"
           >Back to top</a
         >
@@ -1515,11 +1822,11 @@
             type="hidden"
             id="update-privacy-preferences-nonce"
             name="update-privacy-preferences-nonce"
-            value="d46bdb5362"
+            value="1567fa1b44"
           /><input
             type="hidden"
             name="_wp_http_referer"
-            value="/mainframe/products/devops-acceleration-program/training/dbb-self-paced-learning/"
+            value="/mainframe/products/devops-acceleration-program/"
           />
           <header>
             <div class="gdpr-box-title">
@@ -1608,27 +1915,27 @@
     </script>
     <script
       type="text/javascript"
-      src="./dbb-self-paced-learning_files/navigation.js"
+      src="./devops-acceleration-program_files/navigation.js"
     ></script>
     <script
       type="text/javascript"
-      src="./dbb-self-paced-learning_files/skip-link-focus-fix.js"
+      src="./devops-acceleration-program_files/skip-link-focus-fix.js"
     ></script>
     <script
       type="text/javascript"
-      src="./dbb-self-paced-learning_files/tactic.js"
+      src="./devops-acceleration-program_files/tactic.js"
     ></script>
     <script
       type="text/javascript"
-      src="./dbb-self-paced-learning_files/tacticbindlinks.js"
+      src="./devops-acceleration-program_files/tacticbindlinks.js"
     ></script>
     <script
       type="text/javascript"
-      src="./dbb-self-paced-learning_files/new-tab.min.js"
+      src="./devops-acceleration-program_files/new-tab.min.js"
     ></script>
     <script
       type="text/javascript"
-      src="./dbb-self-paced-learning_files/wp-embed.min.js"
+      src="./devops-acceleration-program_files/wp-embed.min.js"
     ></script>
 
     <script>
@@ -1649,12 +1956,12 @@
           {
             title: "Sign In",
             url:
-              "https://developer.ibm.com/sso/login?d=https%3A%2F%2Fdeveloper.ibm.com%2Fmainframe%2Fproducts%2Fdevops-acceleration-program%2Ftraining%2Fdbb-self-paced-learning&lang=en_US",
+              "https://developer.ibm.com/sso/login?d=https%3A%2F%2Fdeveloper.ibm.com%2Fmainframe%2Fproducts%2Fdevops-acceleration-program&lang=en_US",
           },
           {
             title: "Register",
             url:
-              "https://developer.ibm.com/sso/register?lang=en_US&d=https%3A%2F%2Fdeveloper.ibm.com%2Fmainframe%2Fproducts%2Fdevops-acceleration-program%2Ftraining%2Fdbb-self-paced-learning",
+              "https://developer.ibm.com/sso/register?lang=en_US&d=https%3A%2F%2Fdeveloper.ibm.com%2Fmainframe%2Fproducts%2Fdevops-acceleration-program",
           },
         ];
         changeMenu(userLinks);
@@ -1757,6 +2064,35 @@
       })(jQuery);
     </script>
 
+    <script>
+      // smooth scroll to another section when clicking an in-page anchor link
+      $(function() {
+        $(
+          'a[href*="#"]:not([href="#"]):not([role="tablink"]):not([role="button"])'
+        ).click(function() {
+          if (
+            location.pathname.replace(/^\//, "") ==
+              this.pathname.replace(/^\//, "") &&
+            location.hostname == this.hostname
+          ) {
+            var target = $(this.hash);
+            target = target.length
+              ? target
+              : $("[name=" + this.hash.slice(1) + "]");
+            if (target.length) {
+              $("html, body").animate(
+                {
+                  scrollTop: target.offset().top - 50,
+                },
+                400
+              );
+              return false;
+            }
+          }
+        });
+      });
+    </script>
+
     <div id="ibm-overlay-backdrop"></div>
     <div class="pn-modal-overlay" style="display: none;"></div>
     <div class="pn-modal" style="display: none;">
@@ -1764,11 +2100,7 @@
         <div class="pn-modal-hd">Header Here</div>
         <div class="pn-modal-bd"></div>
         <div class="pn-modal-ft"></div>
-        <a
-          href="https://developer.ibm.com/mainframe/products/devops-acceleration-program/training/dbb-self-paced-learning/#"
-          class="pn-modal-close"
-          >x</a
-        >
+        <a href="#" class="pn-modal-close">x</a>
       </div>
     </div>
     <div id="ibm-mobilemenu-screen"></div>

--- a/DevOps_Acceleration_Program/devops-acceleration-program.html
+++ b/DevOps_Acceleration_Program/devops-acceleration-program.html
@@ -7,7 +7,7 @@
   class="applicationcache geolocation history postmessage svg websockets localstorage sessionstorage websqldatabase webworkers hashchange pointerevents canvas audio canvastext video webgl cssgradients multiplebgs opacity rgba inlinesvg hsla supports svgclippaths smil no-touchevents fontface no-generatedcontent textshadow cssanimations backgroundsize borderimage borderradius boxshadow csscolumns csscolumns-width csscolumns-span csscolumns-fill csscolumns-gap csscolumns-rule csscolumns-rulecolor csscolumns-rulestyle csscolumns-rulewidth csscolumns-breakbefore csscolumns-breakafter csscolumns-breakinside flexbox flexboxlegacy cssreflections csstransforms csstransforms3d csstransitions indexeddb indexeddb-deletedatabase js ibm-v18 ibm-cxtype-4g hires mac chrome chrome8 webkit webkit5 ibm-grid-xlarge"
 >
   <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <meta http-equiv="refresh" content="2;url=https://ibm.github.io/mainframe-downloads/DevOps_Acceleration_Program/dap.html" />
     <!-- SITE MON : START (DO NOT DELETE) -->
     <!-- developerWorks monitoring token -->
     <!-- SITE MON : END (DO NOT DELETE) -->
@@ -1188,7 +1188,7 @@
                   id="menu-item-devops-acceleration"
                   class="menu-item menu-item-type-post_type menu-item-object-page page_item current_page_item"
                 >
-                  <a href="devops-acceleration-program.html" tabindex="-1"
+                  <a href="dap.html" tabindex="-1"
                     >DevOps Acceleration Program</a
                   >
                 </li>
@@ -1221,29 +1221,21 @@
                     class="ibm-h1 ibm-textcolor-white-core ibm-padding-bottom-0 ibm-padding-top-1"
                     id="ibm-pagetitle-h1"
                   >
-                    <span>DevOps Acceleration Program</span>
+                    <span>Redirecting...</span>
                   </h1>
 
                   <p
                     class="ibm-h4 ibm-light ibm-textcolor-white-core ibm-padding-top-1 ibm-padding-bottom-1"
                   >
-                    <span>Start your DevOps Transformation Journey</span>
+                    <span>This page should redirect you to the <a href="https://ibm.github.io/mainframe-downloads/DevOps_Acceleration_Program/dap.html">DevOps Acceleration Program</a> page.</span>
                   </p>
-                  <div class="ibm-padding-top-1 ibm-padding-bottom-1">
-                    <p class="ibm-padding-top-0 ibm-button-link ibm-btn-row">
-                      <a href="https://ibm.github.io/z-devops-acceleration-program/" class="ibm-btn-pri ibm-btn-white"
-                        >Z DevOps Guide</a
-                      >
-                      <a href="#contactus" class="ibm-btn-sec ibm-btn-white"
-                        >Contact</a
-                      >
-                    </p>
-                  </div>
+                  
                 </div>
               </div>
             </div>
           </div>
 
+          <!--
           <div class="">
             <div class="ibm-fluid ibm-padding-bottom-r1 ibm-padding-top-r1">
               <div>
@@ -1258,21 +1250,7 @@
                   <div
                     class="ibm-textcolor-default ibm-padding-top-0 ibm-padding-bottom-0"
                   >
-                    <!-- <p>IBM’s DevOps Acceleration Program is <strong>a value-add program</strong> at <strong>no cost</strong> for clients who are getting
-                        started with the DevOps transformation journey. Whether you're transforming in stages or
-                        adopting a big bang approach, IBM's DevOps Acceleration
-                        Program will partner with you to succeed. </p>
-
-                    <p>Our structured approach towards transformation begins with a Value stream assessment. A workshop
-                        to infuse proven practices, lessons learned and as a result provides with a pragmatic
-                        transformation roadmap. </p>
-
-                    <p>The Program also includes free world class training focused on equipping you with the required skills to
-                        make a DevOps transformation successful. </p>
-
-                    <p>The Program extends beyond the roadmap and training to add deployment and adoption services at no cost for the first representative migration.</p>
-
-                    <p>Click the following links to learn more.</p> -->
+                    
                     <p>
                       IBM strongly believes that DevOps transformations are
                       anything but plug-and-play; each enterprise brings with it
@@ -1463,28 +1441,7 @@
               </div>
             </div>
           </div>
-          <!-- 
-<div class="ibm-band ibm-background-neutral-white-20 ibm-textcolor-default">
-    <div class="ibm-fluid ibm-padding-bottom-r1 ibm-padding-top-r1">
-        <div>
-            <div class="ibm-col-12-3 ibm-col-medium-12-12">
-                <h2 class="ibm-h2 ibm-padding-top-0 ibm-padding-bottom-1 ibm-textcolor-blue-60">Value Stream Analysis
-                </h2>
-            </div>
-            <div class="ibm-col-12-9 ibm-col-medium-12-12 ">
-                <div class="ibm-textcolor-default ibm-padding-top-0 ibm-padding-bottom-0">
-                    <h4 class="ibm-h4">Engagement model</h4>
-                    <ul>
-                        <li>Initial recommendations</li>
-                        <li>30-day iteration(s)/MVP</li>
-                        <li>Yearly/6-month recalbration</li>
-                        <li>Pre-deployment consultation</li>
-                    </ul>
-                </div>
-            </div>
-        </div>
-    </div>
-</div> -->
+
 
           <div
             style="display:none !important;"
@@ -1547,24 +1504,6 @@
                           </div>
                         </div>
                       </div>
-                      <!-- Slide 2-->
-                      <!-- 
-                        <div class="ibm-columns content-area-restricted ibm-alternate-background">
-                            <blockquote>
-                                <p>
-                                    <em>
-                                        <span class="ibm-pull-quote-open">“</span>
-                                        <span>When we talk to clients, certainly security and trust are the two biggest
-                                            things. [With IBM Z] there has been absolutely no security breach over the
-                                            past 15 years.</span>
-                                        <span class="ibm-pull-quote-close">”</span>
-                                    </em>
-                                </p>
-                                <p class="ibm-padding-bottom-0">
-                                    —Addie Buissinne, Director of Financial Solutions, Emid
-                                </p>
-                            </blockquote>
-                        </div> -->
                       <div class="ibm-carousel-controls">
                         <div class="ibm-cc-prev"></div>
                         <div
@@ -1579,201 +1518,8 @@
               </div>
             </div>
           </div>
-
-          <div class="ibm-band ibm-background-white-core ibm-textcolor-default">
-            <div class="ibm-fluid ibm-padding-bottom-r1 ibm-padding-top-1">
-              <div>
-                <div class="ibm-col-12-3 ibm-col-medium-12-12">
-                  <h2
-                    class="ibm-h2 ibm-padding-top-1 ibm-padding-bottom-1 ibm-textcolor-blue-50"
-                  >
-                    News, Updates &amp; Resources
-                  </h2>
-                </div>
-                <div class="ibm-col-12-9 ibm-col-medium-12-12 ">
-                  <div
-                    class="ibm-textcolor-default ibm-padding-top-1 ibm-padding-bottom-0 ibm-widget-processed ibm-sameheight-processed"
-                    data-widget="setsameheight"
-                    data-items=".ibm-card"
-                  >
-                    <div
-                      data-widget="carousel"
-                      data-autoplay="false"
-                      data-infinite="true"
-                      class="slick-initialized slick-slider ibm-widget-processed"
-                    >
-                      <!-- Slide 1-->
-                      <div aria-live="polite" class="slick-list draggable">
-                        <div
-                          class="slick-track"
-                          style="opacity: 1; width: 973px; transform: translate3d(0px, 0px, 0px);"
-                          role="listbox"
-                          aria-label="Carousel"
-                        >
-                          <div
-                            class="ibm-columns content-area-restricted slick-slide slick-current slick-active"
-                            data-slick-index="0"
-                            aria-hidden="false"
-                            style="width: 973px;"
-                            tabindex="-1"
-                            role="option"
-                            aria-describedby="slick-slide10"
-                            id="navigation10"
-                          >
-                            <div class="ibm-col-4-3 ibm-center-block">
-                              <div class="ibm-columns">
-                                <!-- <div class="ibm-col-4-1 ibm-col-medium-4-3">
-                                        <div class="ibm-card dl-card" style="height: 347px;">
-                                            <div class="ibm-card__content">
-                                                <h3>Upcoming Webinar
-                                                </h3>
-                                                <p>Join the upcoming webinar on Migration made easy - host SCLM to Git
-                                                    on Z.</p>
-                                            </div>
-                                            <div class="ibm-card__bottom">
-                                                <p class="ibm-btn-row ibm-ind-link ibm-button-link">
-                                                    <a href="https://onlinexperiences.com/Launch/QReg/ShowUUID=58F02EE9-1B7C-4703-BFF1-968D3B249868&LangLocaleID=1033"
-                                                        class="ibm-btn-sec ibm-information-link ibm-btn-blue-50"
-                                                        tabindex="-1">More info</a>
-                                                </p>
-                                            </div>
-                                        </div>
-                                    </div> -->
-
-                                
-
-                                <!-- ADFz host component-->
-                                <div class="ibm-col-12-3 ibm-col-medium-12-12">
-                                  <div
-                                    class="ibm-card dl-card"
-                                    style="height: 196.8px;"
-                                  >
-                                    <div class="ibm-card__content">
-                                      <h3>New Training Sessions Added</h3>
-                                    </div>
-                                    <div class="ibm-card__bottom">
-                                      <p
-                                        class="ibm-btn-row ibm-ind-link ibm-button-link"
-                                      >
-                                        <a
-                                          href="../Training/idzrdz-remote-training.html"
-                                          class="ibm-btn-sec ibm-information-link ibm-btn-blue-50"
-                                          tabindex="0"
-                                          >More info</a
-                                        >
-                                      </p>
-                                    </div>
-                                  </div>
-                                </div>
-
-                                <div class="ibm-col-12-3 ibm-col-medium-12-12">
-                                  <div
-                                    class="ibm-card dl-card"
-                                    style="height: 196.8px;"
-                                  >
-                                    <div class="ibm-card__content">
-                                      <h3>Z DevOps Guide</h3>
-                                    </div>
-                                    <div class="ibm-card__bottom">
-                                      <p
-                                        class="ibm-btn-row ibm-ind-link ibm-button-link"
-                                      >
-                                        <a
-                                          href="https://ibm.github.io/z-devops-acceleration-program/"
-                                          class="ibm-btn-sec ibm-information-link ibm-btn-blue-50"
-                                          tabindex="0"
-                                          >More info</a
-                                        >
-                                      </p>
-                                    </div>
-                                  </div>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-
-                      <!-- Slide 2-->
-
-                      <!--                         
-                        <div class="ibm-columns content-area-restricted">
-
-                            <div class="ibm-col-4-3 ibm-center-block">
-                                <div class="ibm-columns">
-
-
-                                    <div class="ibm-col-4-1 ibm-col-medium-4-3">
-                                        <div class="ibm-card dl-card" style="height: 347px;">
-                                            <div class="ibm-card__content">
-                                                <h3>News item 4
-                                                </h3>
-                                                <p>Curabitur ullamcorper a mi a eleifend. Ut a justo purus. Praesent
-                                                    laoreet ex nec nibh feugiat, non venenatis massa ornare.</p>
-                                            </div>
-                                            <div class="ibm-card__bottom">
-                                                <p class="ibm-btn-row ibm-ind-link ibm-button-link">
-                                                    <a href="#" class="ibm-btn-sec ibm-information-link ibm-btn-blue-50"
-                                                        tabindex="-1">More info</a>
-                                                </p>
-                                            </div>
-                                        </div>
-                                    </div>
-
-          
-                                    <div class="ibm-col-4-1 ibm-col-medium-4-3">
-                                        <div class="ibm-card dl-card" style="height: 347px;">
-                                            <div class="ibm-card__content">
-                                                <h3>News item 5
-                                                </h3>
-                                                <p>Nullam nec lacus vel turpis cursus aliquam a quis arcu. Proin sit
-                                                    amet venenatis arcu. Quisque porttitor iaculis diam varius
-                                                    dignissim. </p>
-                                            </div>
-                                            <div class="ibm-card__bottom">
-                                                <p class="ibm-btn-row ibm-ind-link ibm-button-link">
-                                                    <a href="" class="ibm-btn-sec ibm-information-link ibm-btn-blue-50"
-                                                        tabindex="-1">More info</a>
-                                                </p>
-                                            </div>
-                                        </div>
-                                    </div>
-
-
-                                    <div class="ibm-col-4-1 ibm-col-medium-4-3">
-                                        <div class="ibm-card dl-card" style="height: 347px;">
-                                            <div class="ibm-card__content">
-                                                <h3>News item 6</h3>
-                                                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam et
-                                                    luctus eros, vitae tempor turpis. </p>
-                                            </div>
-                                            <div class="ibm-card__bottom">
-                                                <p class="ibm-btn-row ibm-ind-link ibm-button-link">
-                                                    <a target="_blank" href=""
-                                                        class="ibm-btn-sec ibm-information-link ibm-btn-blue-50"
-                                                        tabindex="-1">More info</a>
-                                                </p>
-                                            </div>
-                                        </div>
-                                    </div>
-
-                                </div>
-                            </div>
-                        </div> -->
-                      <div class="ibm-carousel-controls">
-                        <div class="ibm-cc-prev"></div>
-                        <div
-                          class="ibm-cc-middle"
-                          aria-label="Carousel controls"
-                        ></div>
-                        <div class="ibm-cc-next"></div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
+     
+          -->
 
           <div class="ibm-band ibm-band ibm-background-cool-gray-80 ibm-textcolor-white-core">
             <div class="ibm-fluid ibm-padding-bottom-r1 ibm-padding-top-1">

--- a/Training/Courses.html
+++ b/Training/Courses.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- saved from url=(0082)https://developer.ibm.com/mainframe/products/devops-acceleration-program/training/ -->
 <html
   lang="en-US"
   prefix="og: http://ogp.me/ns#"
@@ -38,7 +39,7 @@
             effectiveDate: "2016-07-18",
             expiryDate: "2020-07-18",
             language: "en-US",
-            publishDate: "2019-11-26",
+            publishDate: "2019-05-07",
             publisher: "IBM Corporation",
             version: "v18",
             pageID: "",
@@ -75,26 +76,27 @@
         },
       };
     </script>
-    <title>IBM Application Discovery & Delivery Intelligence Essentials - Mainframe DEV</title>
+    <title>Training - Mainframe DEV</title>
 
     <!-- This site is optimized with the Yoast SEO plugin v9.0.2 - https://yoast.com/wordpress/plugins/seo/ -->
+    <meta
+      name="description"
+      content="Our learning catalog offers you the training you need, featuring on-demand courses and live remote instructor-led training."
+    />
     <link
       rel="canonical"
-      href="https://developer.ibm.com/mainframe/products/devops-acceleration-program/training/dbb-self-paced-learning/"
+      href="https://developer.ibm.com/mainframe/products/devops-acceleration-program/training/"
     />
     <meta property="og:locale" content="en_US" />
     <meta property="og:type" content="article" />
-    <meta
-      property="og:title"
-      content="IBM Application Discovery & Delivery Intelligence Essentials - Mainframe DEV"
-    />
+    <meta property="og:title" content="Training - Mainframe DEV" />
     <meta
       property="og:description"
-      content="Home Products DevOps Acceleration Program IBM Application Discovery & Delivery Intelligence Essentials Static source analysis for application modernization with IBM ADDI Badge Overview Digital credentials are the future and they are here for Dependency Based Build (DBB). Digital credentials are transforming how IBM is engaging, recognising and managing talent. The course is designed to provide …"
+      content="Our learning catalog offers you the training you need, featuring on-demand courses and live remote instructor-led training."
     />
     <meta
       property="og:url"
-      content="https://developer.ibm.com/mainframe/products/devops-acceleration-program/training/dbb-self-paced-learning/"
+      content="https://developer.ibm.com/mainframe/products/devops-acceleration-program/training/"
     />
     <meta property="og:site_name" content="Mainframe DEV" />
     <script type="application/ld+json">
@@ -143,22 +145,6 @@
             "item": {
               "@id": "https:\/\/developer.ibm.com\/mainframe\/products\/devops-acceleration-program\/training\/",
               "name": "Training"
-            }
-          },
-          {
-            "@type": "ListItem",
-            "position": 5,
-            "item": {
-              "@id": "https:\/\/developer.ibm.com\/mainframe\/products\/devops-acceleration-program\/training\/dbb-self-paced-learning\/",
-              "name": "IBM Dependency Based Build Fundamentals"
-            }
-          },
-          {
-            "@type": "ListItem",
-            "position": 6,
-            "item": {
-              "@id": "https:\/\/developer.ibm.com\/mainframe\/products\/devops-acceleration-program\/training\/addi-self-paced-learning\/",
-              "name": "IBM Application Discovery & Delivery Intelligence Essentials"
             }
           }
         ]
@@ -320,7 +306,7 @@
       })(window, document, window._wpemojiSettings);
     </script>
     <script
-      src="./dbb-self-paced-learning_files/wp-emoji-release.min.js"
+      src="./Training_files/wp-emoji-release.min.js"
       type="text/javascript"
       defer=""
     ></script>
@@ -341,214 +327,76 @@
     <link
       rel="stylesheet"
       id="gdpr-css"
-      href="./dbb-self-paced-learning_files/gdpr-public.css"
+      href="./Training_files/gdpr-public.css"
       type="text/css"
       media="all"
     />
     <link
       rel="stylesheet"
       id="tab-styles-css"
-      href="./dbb-self-paced-learning_files/tab-styles.css"
+      href="./Training_files/tab-styles.css"
       type="text/css"
       media="all"
     />
     <link
       rel="stylesheet"
       id="home-v17-styles-css"
-      href="./dbb-self-paced-learning_files/home.css"
+      href="./Training_files/home.css"
       type="text/css"
       media="all"
     />
     <link
       rel="stylesheet"
       id="rotatingtweets-css"
-      href="./dbb-self-paced-learning_files/style.css"
+      href="./Training_files/style.css"
       type="text/css"
       media="all"
     />
     <link
       rel="stylesheet"
       id="dwboomer-style-css"
-      href="./dbb-self-paced-learning_files/style(1).css"
+      href="./Training_files/style(1).css"
       type="text/css"
       media="all"
     />
     <link
       rel="stylesheet"
       id="dashicons-css"
-      href="./dbb-self-paced-learning_files/dashicons.min.css"
+      href="./Training_files/dashicons.min.css"
       type="text/css"
       media="all"
     />
     <link
       rel="stylesheet"
       id="pagepost_css-css"
-      href="./dbb-self-paced-learning_files/pagepost.css"
+      href="./Training_files/pagepost.css"
       type="text/css"
       media="all"
     />
     <style id="pagepost_css-inline-css" type="text/css">
-      @media only screen and (max-width: 1000px) {
-        #intro-svg {
-          padding: 15px !important;
-          margin-top: 0 !important;
-        }
-
-        .img-div {
-          text-align: center;
-        }
-
-        #whats-new-div {
-          padding-right: 0 !important;
-        }
-      }
-
-      .box-div {
-        padding: 4em !important;
-      }
-
-      #whats-new-div {
-        padding-right: 80px;
-      }
-
       .site-content {
         padding-top: 0 !important;
-      }
-
-      .ibm-fluid {
-        font-weight: 300;
-      }
-
-      .zs-color-section {
-        padding-top: 30px;
-      }
-
-      #intro-svg {
-        padding: 0 45px;
-        margin-top: -45px;
-      }
-
-      .info-div {
-      }
-
-      .info-div h2 {
-        font-weight: 500;
-      }
-
-      .img-div {
-      }
-
-      .background-special-blue {
-        background: #ebf3fe;
-      }
-
-      #bannerstrip {
-        padding: 20px 0;
-      }
-
-      #bannerstrip a {
-        color: white;
-        font-size: 20px;
-        text-transform: uppercase;
-        font-weight: 400;
-        padding: 0 20px;
-        border-right: 2px solid white;
-        line-height: 1;
-        display: inline-block;
-      }
-
-      #bannerstrip a:last-of-type {
-        border-right: none !important;
-      }
-
-      #bannerstrip > .ibm-fluid {
-        padding: 0 !important;
-      }
-
-      #whyz {
-        background: #e7e9f7;
-      }
-
-      img.sideimg {
-        padding: 0 50px;
-        margin-bottom: 10px;
-        box-sizing: border-box;
-      }
-
-      #yt-vid iframe {
-        width: 100%;
-      }
-
-      .integrationul li img {
-        width: 30px;
-        height: auto;
-        max-height: 100%;
-        line-height: 1;
-        vertical-align: middle;
-        margin-right: 7px;
-      }
-
-      .integrationul li.indent {
-        margin-left: -1.8rem;
-      }
-
-      .integrationul li.indent:before {
-        content: "" !important;
-      }
-
-      .no_bullet li.cloud:before {
-        content: "\00a0\00a0";
-        background-image: url("https://developer.ibm.com/static/site-id/46/nodejsforzos/cloudbullet.png");
-        background-size: contain;
-        background-repeat: no-repeat;
-        background-position: center;
-      }
-      ol[type="a"] li:before {
-        content: counter(item, lower-alpha) ". " !important;
-      }
-      #ibm-leadspace-head {
-        border-bottom: none !important;
-      }
-
-      .ibm-card__image > svg {
-        max-width: 50%;
-        margin-bottom: -25px;
-        fill: white;
-      }
-
-      .ibm-card__image {
-        padding: 1.5rem;
-        text-align: center;
       }
     </style>
     <link
       rel="stylesheet"
       id="pnext.utils-css"
-      href="./dbb-self-paced-learning_files/pnext.utils.css"
+      href="./Training_files/pnext.utils.css"
       type="text/css"
       media="all"
     />
-    <script
-      type="text/javascript"
-      src="./dbb-self-paced-learning_files/www.js"
-    ></script>
+    <script type="text/javascript" src="./Training_files/www.js"></script>
     <style></style>
     <script
       type="text/javascript"
-      src="./dbb-self-paced-learning_files/jquery.cycle.all.min.js"
+      src="./Training_files/jquery.cycle.all.min.js"
     ></script>
     <script
       type="text/javascript"
-      src="./dbb-self-paced-learning_files/rotating_tweet.js"
+      src="./Training_files/rotating_tweet.js"
     ></script>
-    <script
-      type="text/javascript"
-      src="./dbb-self-paced-learning_files/dyntabs.js"
-    ></script>
-    <script
-      type="text/javascript"
-      src="./dbb-self-paced-learning_files/masonry.js"
-    ></script>
+    <script type="text/javascript" src="./Training_files/dyntabs.js"></script>
+    <script type="text/javascript" src="./Training_files/masonry.js"></script>
     <script type="text/javascript">
       /* <![CDATA[ */
       var GDPR = {
@@ -562,24 +410,18 @@
     </script>
     <script
       type="text/javascript"
-      src="./dbb-self-paced-learning_files/gdpr-public.js"
+      src="./Training_files/gdpr-public.js"
     ></script>
     <script
       type="text/javascript"
-      src="./dbb-self-paced-learning_files/tab-dropdown.js"
+      src="./Training_files/tab-dropdown.js"
     ></script>
+    <script type="text/javascript" src="./Training_files/mainframe.js"></script>
     <script
       type="text/javascript"
-      src="./dbb-self-paced-learning_files/mainframe.js"
+      src="./Training_files/pnext.utils.js"
     ></script>
-    <script
-      type="text/javascript"
-      src="./dbb-self-paced-learning_files/pnext.utils.js"
-    ></script>
-    <script
-      type="text/javascript"
-      src="./dbb-self-paced-learning_files/ida_stats.js"
-    ></script>
+    <script type="text/javascript" src="./Training_files/ida_stats.js"></script>
     <link
       rel="https://api.w.org/"
       href="https://developer.ibm.com/mainframe/wp-json/"
@@ -596,24 +438,21 @@
       href="https://developer.ibm.com/mainframe/wp-includes/wlwmanifest.xml"
     />
     <meta name="generator" content="WordPress 4.9.9" />
-    <link rel="shortlink" href="https://developer.ibm.com/mainframe/?p=18535" />
+    <link rel="shortlink" href="https://developer.ibm.com/mainframe/?p=16082" />
     <link
       rel="alternate"
       type="application/json+oembed"
-      href="https://developer.ibm.com/mainframe/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fdeveloper.ibm.com%2Fmainframe%2Fproducts%2Fdevops-acceleration-program%2Ftraining%2Fdbb-self-paced-learning%2F"
+      href="https://developer.ibm.com/mainframe/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fdeveloper.ibm.com%2Fmainframe%2Fproducts%2Fdevops-acceleration-program%2Ftraining%2F"
     />
     <link
       rel="alternate"
       type="text/xml+oembed"
-      href="https://developer.ibm.com/mainframe/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fdeveloper.ibm.com%2Fmainframe%2Fproducts%2Fdevops-acceleration-program%2Ftraining%2Fdbb-self-paced-learning%2F&amp;format=xml"
+      href="https://developer.ibm.com/mainframe/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fdeveloper.ibm.com%2Fmainframe%2Fproducts%2Fdevops-acceleration-program%2Ftraining%2F&amp;format=xml"
     />
 
-    <link href="./dbb-self-paced-learning_files/www.css" rel="stylesheet" />
-    <link
-      href="./dbb-self-paced-learning_files/grid-fluid.css"
-      rel="stylesheet"
-    />
-    <link href="./dbb-self-paced-learning_files/tables.css" rel="stylesheet" />
+    <link href="./Training_files/www.css" rel="stylesheet" />
+    <link href="./Training_files/grid-fluid.css" rel="stylesheet" />
+    <link href="./Training_files/tables.css" rel="stylesheet" />
 
     <script type="text/javascript">
       IBMCore.common.util.config.set({
@@ -630,14 +469,72 @@
         survey: { global_percent: 0 },
       });
     </script>
-    <style id="ibm-masthead-hidelinks">
-      @media screen and (max-width: 457px) {
-        .ibm-masthead-categories,
-        #ibm-megamenu-sections {
-          display: none;
-        }
+
+    <script async="" src="./Training_files/aksb.min.js"></script>
+    <script>
+      var w = window;
+      if (
+        w.performance ||
+        w.mozPerformance ||
+        w.msPerformance ||
+        w.webkitPerformance
+      ) {
+        var d = document;
+        (AKSB = w.AKSB || {}),
+          (AKSB.q = AKSB.q || []),
+          (AKSB.mark =
+            AKSB.mark ||
+            function(e, _) {
+              AKSB.q.push(["mark", e, _ || new Date().getTime()]);
+            }),
+          (AKSB.measure =
+            AKSB.measure ||
+            function(e, _, t) {
+              AKSB.q.push(["measure", e, _, t || new Date().getTime()]);
+            }),
+          (AKSB.done =
+            AKSB.done ||
+            function(e) {
+              AKSB.q.push(["done", e]);
+            }),
+          AKSB.mark("firstbyte", new Date().getTime()),
+          (AKSB.prof = {
+            custid: "351329",
+            ustr: "",
+            originlat: "0",
+            clientrtt: "17",
+            ghostip: "184.84.243.148",
+            ipv6: false,
+            pct: "10",
+            clientip: "142.120.63.112",
+            requestid: "6b5240ef",
+            region: "24910",
+            protocol: "h2",
+            blver: 14,
+            akM: "x",
+            akN: "ae",
+            akTT: "O",
+            akTX: "1",
+            akTI: "6b5240ef",
+            ai: "335196",
+            ra: "false",
+            pmgn: "",
+            pmgi: "",
+            pmp: "",
+            qc: "",
+          }),
+          (function(e) {
+            var _ = d.createElement("script");
+            (_.async = "async"), (_.src = e);
+            var t = d.getElementsByTagName("script"),
+              t = t[t.length - 1];
+            t.parentNode.insertBefore(_, t);
+          })(
+            ("https:" === d.location.protocol ? "https:" : "http:") +
+              "//ds-aksb-a.akamaihd.net/aksb.min.js"
+          );
       }
-    </style>
+    </script>
     <style id="ibm-sitenav-menu-hidelinks">
       @media screen and (max-width: 1075px) {
         .ibm-sitenav-menu-container .ibm-sitenav-menu-list > ul > li {
@@ -650,12 +547,21 @@
         }
       }
     </style>
+    <style id="ibm-masthead-hidelinks">
+      @media screen and (max-width: 457px) {
+        .ibm-masthead-categories,
+        #ibm-megamenu-sections {
+          display: none;
+        }
+      }
+    </style>
   </head>
 
   <body
     id="ibm-com"
-    class="page-template page-template-page-templates page-template-empty page-template-page-templatesempty-php page page-id-18535 page-child parent-pageid-16082 ibm-com ibm-type group-blog ibm-sitenav-menu"
+    class="page-template page-template-page-templates page-template-empty page-template-page-templatesempty-php page page-id-16082 page-parent page-child parent-pageid-17162 ibm-com ibm-type group-blog ibm-sitenav-menu"
   >
+    
     <style>
       .code_p_announcement .code_content__wrap {
         background: #4178be;
@@ -695,7 +601,7 @@
     <div id="ibm-top" class="ibm-landing-page">
       <a
         class="skip-link screen-reader-text"
-        href="https://developer.ibm.com/mainframe/products/devops-acceleration-program/training/dbb-self-paced-learning/#main"
+        href="https://developer.ibm.com/mainframe/products/devops-acceleration-program/training/#main"
         >Skip to content</a
       >
 
@@ -721,6 +627,7 @@
           </div>
         </div>
       </div>
+      
       <div
         class="ibm-mobilemenu ibm-hide"
         id="ibm-burger-menu-container"
@@ -733,7 +640,7 @@
           <p class="ibm-icononly ibm-fright ibm-ind-link ibm-nospacing">
             <a
               class="ibm-close-link"
-              href="https://developer.ibm.com/mainframe/products/devops-acceleration-program/training/dbb-self-paced-learning/?lnk=hm#"
+              href="https://developer.ibm.com/mainframe/products/devops-acceleration-program/training/?lnk=hm#"
               >Close</a
             >
           </p>
@@ -765,7 +672,7 @@
             </li>
             <li
               id="menu-item-16086"
-              class="menu-item menu-item-type-post_type menu-item-object-page current-page-ancestor menu-item-16086"
+              class="menu-item menu-item-type-post_type menu-item-object-page current-menu-item page_item page-item-16082 current_page_item menu-item-16086"
             >
               <a
                 href="https://developer.ibm.com/mainframe/products/devops-acceleration-program/training/?lnk=hm"
@@ -1216,12 +1123,13 @@
                     </li>
                   </ul>
                 </li>
+
                 <li
                   id="menu-item-devops-acceleration"
                   class="menu-item menu-item-type-post_type menu-item-object-page page_item"
                 >
                   <a
-                    href="../DevOps_Acceleration_Program/devops-acceleration-program.html"
+                    href="../DevOps_Acceleration_Program/dap.html"
                     tabindex="-1"
                     >DevOps Acceleration Program</a
                   >
@@ -1253,13 +1161,14 @@
                     class="ibm-h1 ibm-textcolor-white-core ibm-padding-bottom-0 ibm-padding-top-1"
                     id="ibm-pagetitle-h1"
                   >
-                    <span>DevOps Distance Learning Program</span>
+                    <span>Training</span>
                   </h1>
 
                   <p
                     class="ibm-h4 ibm-light ibm-textcolor-white-core ibm-padding-top-1 ibm-padding-bottom-1"
                   >
-                    <span>Instructor Led Training</span
+                    <span
+                      >Start your DevOps Digital Transformation Journey</span
                     >
                   </p>
                 </div>
@@ -1274,69 +1183,7 @@
                   <h2
                     class="ibm-h2 ibm-padding-top-0 ibm-padding-bottom-1 ibm-textcolor-blue-50"
                   >
-                  Course Calendar
-                  </h2>
-                </div>
-                <div
-                  class="ibm-col-12-7 ibm-col-medium-12-12"
-                  style="padding-top: 1rem;"
-                >
-                  <a
-                    href="https://ibm.github.io/mainframe-downloads/Training/idzrdz-remote-training.html"
-                    >https://ibm.github.io/mainframe-downloads/Training/idzrdz-remote-training.html</a
-                  >
-                </div>
-                <div class="ibm-col-12-2 ibm-col-medium-12-12 ibm-hide">
-                  <img
-                    src="./dbb-self-paced-learning_files/idzbadge.png"
-                    alt="DBB Badge"
-                  />
-                </div>
-              </div>
-            </div>
-
-            <div class="ibm-fluid ibm-padding-bottom-r1 ibm-padding-top-r1">
-              <div>
-                <div class="ibm-col-12-3 ibm-col-medium-12-12">
-                  <h2
-                    class="ibm-h2 ibm-padding-top-0 ibm-padding-bottom-1 ibm-textcolor-blue-50"
-                  >
-                    Badge Overview
-                  </h2>
-                </div>
-                <div class="ibm-col-12-7 ibm-col-medium-12-12 ">
-                  <div
-                    class="ibm-textcolor-default ibm-padding-top-0 ibm-padding-bottom-0"
-                  >
-                    <p>
-                        Digital Badges are shaping the future of professional credentials, and now they are here for 
-                        <strong>Application Delivery Foundation for z/OS (ADFz)</strong> 
-                        through the 
-                        <a href="https://ibm.github.io/mainframe-downloads/Training/idzrdz-remote-training.html">
-                            ADFz Distance Learning Curriculum
-                        </a>
-                        .
-                    </p>
-                  </div>
-                </div>
-                <div class="ibm-col-12-2 ibm-col-medium-12-12 ibm-hide">
-                  <img
-                    src="./dbb-self-paced-learning_files/idzbadge.png"
-                    alt="DBB Badge"
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div class="ibm-background-neutral-white-30">
-            <div class="ibm-fluid ibm-padding-bottom-r1 ibm-padding-top-r1">
-              <div>
-                <div class="ibm-col-12-3 ibm-col-medium-12-12">
-                  <h2
-                    class="ibm-h2 ibm-padding-top-0 ibm-padding-bottom-1 ibm-textcolor-blue-50"
-                  >
-                    Badge Description
+                    Overview
                   </h2>
                 </div>
                 <div class="ibm-col-12-9 ibm-col-medium-12-12 ">
@@ -1344,133 +1191,395 @@
                     class="ibm-textcolor-default ibm-padding-top-0 ibm-padding-bottom-0"
                   >
                     <p>
-                        The badge earner understands and can articulate foundational knowledge of 
-                        <a href="https://www.ibm.com/products/app-delivery-foundation-for-zos">
-                            IBM Application Delivery Foundation for z/OS (ADFz)
-                        </a>
-                        . Through completion of workshops and associated labs, the individual has gained 
-                        knowledge of the following: Mastering elementary Eclipse terms & concepts; 
-                        Navigating seamlessly through the product; Customizing preferences, views & perspectives; 
-                        Analyzing, editing & debugging programs; Coding & testing DB2/SQL statements; 
-                        and Managing Jobs & remote files & data sets.
-                    </p>
-                    <p>
-                        This program is a remote deep dive/technical training offering from IBM ADFz enablement 
-                        specialists. It equips you with the skills for enterprise-level production work with ADFz. 
-                        The feedback from clients on this training program is overwhelmingly positive, and the 
-                        added bonus is that you now get to authenticate your ADFz cred with a Digital Badge.
-                    </p>
-                    <p>
-                        Upon completion of this course, students will be able to perform the following using IDz:
-                    </p>
-                    <ul>
-                      <li>
-                        Module 1 – The IDz Workbench and introduction to Eclipse for ISPF Developers
-                      </li>
-                      <li>
-                        Module 2 – Editing Program Source
-                      </li>
-                      <li>
-                        Module 3 – Analyzing COBOL Programs
-                      </li>
-                      <li>
-                        Module 4 – Introduction to IDz Remote Systems’ Features
-                      </li>
-                      <li>
-                        Module 5 – Dataset Access and Organization
-                      </li>
-                      <li>
-                        Module 6 – ISPF 3.x Options, Batch Job Submission &amp; Management
-                      </li>
-                      <li>
-                        Module 7 – Git usage in IDz
-                      </li>
-                      <li>
-                        Module 8 – The DB2 and SQL Data Tools
-                      </li>
-                      <li>
-                        Module 9 – Debugging z/OS COBOL Applications using IDz
-                      </li>
-                    </ul>
-
-                    <strong
-                      ><span>What it takes to earn this badge</span></strong
-                    >
-                    <p>
-                        Successful completion of the ADFz Distance Learning Curriculum, consisting of 9 modules, including the following:
-                    </p>
-                    <ul>
-                        <li>
-                            Content/Concepts & Facilities: Presentation + Slideware
-                        </li>
-                        <li>
-                            Hands-on Labs and Workshops
-                        </li>
-                        <li>
-                            Application of all ADFz/IDz skills and techniques to production application development work
-                        </li>
-                    </ul>
-                    <p>
-                        You will receive your badge within 10 business days of completing the training curriculum. 
-                        This badge can be obtained by any IBM employee or non-IBM employee.
-                    </p>
-                    <strong
-                      ><span
-                        >More about the IBM Digital Badge program</span
-                      ></strong
-                    >
-                    <p>
-                        IBM has established a Digital Badge Program to recognize our employees' significant achievements 
-                        and skills attainment. IBM credentials are recognized, respected and valued globally in the IT 
-                        industry. This program will enable you to easily and quickly share verified proof of your 
-                        achievement both within IBM and externally. Where applicable, your IBM credentials will be 
-                        represented by a digital image that contains verified metadata describing your qualifications 
-                        and the rigorous process necessary to earn them.
-                    </p>
-                    <strong><span>Badge Queries</span></strong>
-                    <p>
-                        For questions about the IDz Basics badge program, such as a missing or incorrect badge or how 
-                        to earn the badge, contact
-                        <a href="mailto:dat@ibm.com"
-                        >dat@ibm.com</a>                            >
-                    </p>
-                    <p>
-                      Credly Support: For questions related to your Credly badge earner account and profile, as well as 
-                      issues related to claiming your badge after receiving a notification, go to support.credly.com.
-                    </p>
-                    <p>
-                      For Frequently Asked Questions about the IBM Digital Badge
-                      Program, click
-                      <a
-                        href="https://www-03.ibm.com/services/learning/ites.wss/zz-en?pageType=page&amp;c=P430723G05904L37"
-                        >here</a
-                      >.
-                    </p>
-                    <strong><span>Badge Privacy Statement</span></strong>
-                    <p>
-                      NOTICE: IBM leverages the services of Credly, a 3rd party data processor authorized 
-                      by IBM and located in the United States, to assist in the administration of 
-                      the IBM Digital Badge program. In order to issue you an IBM Digital Badge, your 
-                      personal information (name, email address, and badge earned) will be shared 
-                      with Credly. You will receive an email notification from Credly with instructions 
-                      for claiming the badge. Your personal information is used to issue your badge 
-                      and for program reporting and operational purposes. IBM may share the personal information
-                      collected with IBM subsidiaries and third parties globally. It will be handled 
-                      in a manner consistent with IBM privacy practices.The IBM Privacy Statement can be viewed 
-                      here: 
-                      <a href="https://www.ibm.com/privacy/us/en/">
-                        https://www.ibm.com/privacy/us/en/
-                      </a>
-                      IBM employees can view the IBM Internal Privacy Statement here: 
-                      <a href="https://w3.ibm.com/w3publisher/w3-privacy-notice">
-                        https://w3.ibm.com/w3publisher/w3-privacy-notice
-                      </a>.
+                      Our learning catalog offers you the training you need,
+                      featuring on-demand courses and live remote instructor-led
+                      training. Our focus is to equip you with the skills
+                      required to make a DevOps transformation successful.
                     </p>
                   </div>
                 </div>
               </div>
             </div>
           </div>
+          
+          <div class="ibm-background-neutral-white-30">
+            <div class="ibm-fluid ibm-padding-bottom-r1 ibm-padding-top-r1">
+              <div>
+                <div class="ibm-col-12-3 ibm-col-medium-12-12">
+                  <h2
+                    class="ibm-h2 ibm-padding-top-0 ibm-padding-bottom-1 ibm-textcolor-blue-50"
+                  >
+                    Training
+                  </h2>
+                </div>
+                <div class="ibm-col-12-9 ibm-col-medium-12-12 ">
+                  <div
+                    class="ibm-textcolor-default ibm-padding-top-0 ibm-padding-bottom-0"
+                  >
+                    <!-- tilestart -->
+
+                    <div
+                      class="ibm-columns ibm-fluid ibm-widget-processed ibm-sameheight-processed"
+                      data-items=".ibm-card"
+                      data-widget="setsameheight"
+                    >
+                      <div class="card-equal ibm-col-12-4 ibm-col-medium-12-12 ibm-col-sm-12-12">
+                        <div class="ibm-card" style="height: 250px;">
+                          <div class="ibm-card__content">
+                            <h3 class="ibm-h3">
+                                DevOps Distance Learning Program
+                            </h3>
+                            <p>
+                                Instructor Led Training
+                            </p>
+                            
+                          </div>
+                          <div class="ibm-card__bottom">
+                            <p class="ibm-btn-row">
+                              <a href="adfz-instructor-led-learning.html" class="ibm-btn-pri ibm-btn-teal-50">
+                                Learn more
+                              </a>
+                            </p>
+                          </div>
+                        </div>
+                      </div>
+
+                      <div class="card-equal ibm-col-12-4 ibm-col-medium-12-6 ibm-col-sm-12-12">
+                        <div class="ibm-card" style="height: 250px;">
+                          <div class="ibm-card__content">
+                            <h3 class="ibm-h3">IBM Developer for Z</h3>
+                            <p>Self-paced learning</p>
+                          </div>
+                          <div class="ibm-card__bottom">
+                            <p class="ibm-btn-row">
+                              <a href="idz-self-paced-learning.html" class="ibm-btn-pri ibm-btn-teal-50">
+                                Learn more
+                              </a>
+                            </p>
+                          </div>
+                        </div>
+                      </div>
+
+                      <div class="card-equal ibm-col-12-4 ibm-col-medium-12-6 ibm-col-sm-12-12" >
+                        <div class="ibm-card" style="height: 250px;">
+                          <div class="ibm-card__content">
+                            <h3 class="ibm-h3">IBM Dependency Based Build</h3>
+                            <p>Self-paced learning</p>
+                          </div>
+                          <div class="ibm-card__bottom">
+                            <p class="ibm-btn-row">
+                              <a href="dbb-self-paced-learning.html" class="ibm-btn-pri ibm-btn-teal-50">
+                                Learn more
+                              </a>
+                            </p>
+                          </div>
+                        </div>
+                      </div>
+                      
+                      <div class="card-equal ibm-col-12-4 ibm-col-medium-12-6 ibm-col-sm-12-12">
+                        <div class="ibm-card" style="height: 250px;">
+                          <div class="ibm-card__content">
+                            <h3 class="ibm-h3">IBM Application Discovery & Delivery Intelligence</h3>
+                            <p>Self-paced learning</p>
+                          </div>
+                          <div class="ibm-card__bottom">
+                            <p class="ibm-btn-row">
+                              <a href="./addi-self-paced-learning.html" class="ibm-btn-pri ibm-btn-teal-50">
+                                Learn more
+                              </a>
+                            </p>
+                          </div>
+                        </div>
+                      </div>
+
+                      <div class="card-equal ibm-col-12-4 ibm-col-medium-12-6 ibm-col-sm-12-12">
+                        <div class="ibm-card" style="height: 250px;">
+                          <div class="ibm-card__content">
+
+                            <h3 class="ibm-h3">Cloud native development with IBM Z and Cloud Modernization Stack Fundamentals                       
+                            </h3>
+                            <p>Self-paced learning</p>
+                          </div>
+                          <div class="ibm-card__bottom">
+                            <p class="ibm-btn-row">
+                              <a href="./wazideveloper-self-paced-learning.html" class="ibm-btn-pri ibm-btn-teal-50">
+                                Learn more
+                              </a>
+                            </p>
+                          </div>
+                        </div>
+                      </div>
+
+                      <div class="card-equal ibm-col-12-4 ibm-col-medium-12-6 ibm-col-sm-12-12">
+                        <div class="ibm-card" style="height: 250px;">
+                          <div class="ibm-card__content">
+                            <h3 class="ibm-h3">Z DevOps Testing Fundamentals 
+                            </h3>
+                            <p>Self-paced learning</p>
+                          </div>
+                          <div class="ibm-card__bottom">
+                            <p class="ibm-btn-row">
+                              <a href="./zdevops-testing-learning.html" class="ibm-btn-pri ibm-btn-teal-50">
+                                Learn more
+                              </a>
+                            </p>
+                          </div>
+                        </div>
+                      </div>
+                      <div class="card-equal ibm-col-12-4 ibm-col-medium-12-6 ibm-col-sm-12-12">
+                        <div class="ibm-card" style="height: 250px;">
+                          <div class="ibm-card__content">
+                            <h3 class="ibm-h3">IBM watsonx Code Assistant for Z Fundamentals 
+                            </h3>
+                            <p>Self-paced learning</p>
+                          </div>
+                          <div class="ibm-card__bottom">
+                            <p class="ibm-btn-row">
+                              <a
+                                href="https://ibm.github.io/mainframe-downloads/Training/wca4z-learning.html"
+                                class="ibm-btn-pri ibm-btn-teal-50"
+                                >
+                                Learn more
+                              </a>
+                            </p>
+                          </div>
+                        </div>
+                      </div>
+                      <div class="card-equal ibm-col-12-4 ibm-col-medium-12-6 ibm-col-sm-12-12">
+                        <div class="ibm-card" style="height: 250px;">
+                          <div class="ibm-card__content">
+                            <h3 class="ibm-h3">Z DevOps CI/CD Enablement
+                            </h3>
+                            <p>Learning Collection</p>
+                          </div>
+                          <div class="ibm-card__bottom">
+                            <p class="ibm-btn-row">
+                              <a
+                                href="https://www.ibm.com/training/collection/zdevopstransformationcicdpipelineswithdbbgit"
+                                class="ibm-btn-pri ibm-btn-teal-50"
+                                >
+                                Learn more
+                              </a>
+                            </p>
+                          </div>
+                        </div>
+                      </div>
+
+                  
+                      <!-- <div class="ibm-col-12-4 ibm-col-medium-12-6 ibm-col-sm-12-12">
+
+                        </div> -->
+
+                      <!-- <div class="ibm-col-12-4 ibm-col-medium-12-6 ibm-col-sm-12-12">
+                            <div class="ibm-card">
+                                <div class="ibm-card__content">
+                                    <h3 class="ibm-h3">IDz/RDz</h3>
+                                    <p>Instructor-led Virtual Training</p>
+                                </div>
+                                <div class="ibm-card__bottom">
+                                    <p class="ibm-btn-row">
+                                        <a href="https://developer.ibm.com/mainframe/idzrdz-remote-training"
+                                            class="ibm-btn-pri ibm-btn-teal-50">Learn more</a>
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="ibm-col-12-4 ibm-col-medium-12-6 ibm-col-sm-12-12">
+                            <div class="ibm-card">
+                                <div class="ibm-card__content">
+                                    <h3 class="ibm-h3">Git for ISPF Developers</h3>
+                                    <p>Instructor-led Virtual Training</p>
+                                </div>
+                                <div class="ibm-card__bottom">
+                                    <p class="ibm-btn-row">
+                                        <a href="https://developer.ibm.com/mainframe/idzrdz-remote-training"
+                                            class="ibm-btn-pri ibm-btn-teal-50">Learn more</a>
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="ibm-col-12-4 ibm-col-medium-12-6 ibm-col-sm-12-12">
+
+                        </div>
+                        <div class="ibm-col-12-4 ibm-col-medium-12-6 ibm-col-sm-12-12">
+                            <div class="ibm-card">
+                                <div class="ibm-card__content">
+                                    <h3 class="ibm-h3">IBM Application Discovery</h3>
+                                    <p>Instructor-led Virtual Training</p>
+                                </div>
+                                <div class="ibm-card__bottom">
+                                    <p class="ibm-btn-row">
+                                        <a href="https://developer.ibm.com/mainframe/idzrdz-remote-training"
+                                            class="ibm-btn-pri ibm-btn-teal-50">Learn more</a>
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="ibm-col-12-4 ibm-col-medium-12-6 ibm-col-sm-12-12">
+                            <div class="ibm-card">
+                                <div class="ibm-card__content">
+                                    <h3 class="ibm-h3">IBM Z Open Development</h3>
+                                    <p>Instructor-led Virtual Training</p>
+                                </div>
+                                <div class="ibm-card__bottom">
+                                    <p class="ibm-btn-row">
+                                        <a href="https://developer.ibm.com/mainframe/idzrdz-remote-training"
+                                            class="ibm-btn-pri ibm-btn-teal-50">Learn more</a>
+                                    </p>
+                                </div>
+                            </div>
+                        </div> -->
+                    </div>
+                    <!-- tileend -->
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          
+          <div class="">
+            <div class="ibm-fluid ibm-padding-bottom-r1 ibm-padding-top-r1">
+              <div>
+                <div class="ibm-col-12-3 ibm-col-medium-12-12">
+                  <h2 class="ibm-h2 ibm-padding-top-0 ibm-padding-bottom-1 ibm-textcolor-blue-50">
+                  Resources
+                  </h2>
+                </div>
+                <div class="ibm-col-12-9 ibm-col-medium-12-12 ">
+                  <div class="ibm-textcolor-default ibm-padding-top-0 ibm-padding-bottom-0">
+                    <!-- tilestart -->
+
+                    <div
+                      class="ibm-columns ibm-fluid ibm-widget-processed ibm-sameheight-processed"
+                      data-items=".ibm-card"
+                      data-widget="setsameheight"
+                    >
+
+                      <div class="card-equal ibm-col-12-4 ibm-col-medium-12-6 ibm-col-sm-12-12">
+                        <div class="ibm-card" style="height: 250px;">
+                          <div class="ibm-card__content">
+                            <h3 class="ibm-h3">Application Discovery & Delivery Intelligence (ADDI) Accelerator</h3>
+                            <p>Introductory Materials & Guides</p>
+                          </div>
+                          <div class="ibm-card__bottom">
+                            <p class="ibm-btn-row">
+                              <a
+                                href="https://community.ibm.com/community/user/ibmz-and-linuxone/groups/community-home/librarydocuments/viewdocument?DocumentKey=4cb329ed-1515-45f1-8ec3-9c72df457ced&Step=1&CommunityKey=336bb81c-ac97-46d5-95bb-319e41258fbe&ReturnUrl=%2fcommunity%2fuser%2fibmz-and-linuxone%2fgroups%2fcommunity-home%2flibrarydocuments%2fviewdocument%3fDocumentKey%3d4cb329ed-1515-45f1-8ec3-9c72df457ced%26Step%3d1%26CommunityKey%3d336bb81c-ac97-46d5-95bb-319e41258fbe%26ReturnUrl%3d%252fcommunity%252fuser%252fibmz-and-linuxone%252fgroups%252fcommunity-home%252flibrarydocuments%252fviewdocument%253fDocumentKey%253d4cb329ed-1515-45f1-8ec3-9c72df457ced%2526Step%253d1%2526CommunityKey%253d336bb81c-ac97-46d5-95bb-319e41258fbe%2526ReturnUrl%253d%25252fcommunity%25252fuser%25252fibmz-and-linuxone%25252fviewdocument%25252faccelerator-application-discovery%25253fCommunityKey%25253d5bf125bd-1412-41a8-8843-750e6590b9c5%252526tab%25253dlibrarydocuments"
+                                class="ibm-btn-pri ibm-btn-teal-50"
+                                >Learn more</a
+                              >
+                            </p>
+                          </div>
+                        </div>
+                      </div>
+  
+                      <div class="card-equal ibm-col-12-4 ibm-col-medium-12-6 ibm-col-sm-12-12">
+                        <div class="ibm-card" style="height: 250px;">
+                          <div class="ibm-card__content">
+                            <h3 class="ibm-h3">Dependency Based Build (DBB) Accelerator</h3>
+                            <p>Getting Started - Technical Resources</p>
+                          </div>
+                          <div class="ibm-card__bottom">
+                            <p class="ibm-btn-row">
+                              <a
+                                href="https://community.ibm.com/community/user/ibmz-and-linuxone/groups/community-home/librarydocuments/viewdocument?DocumentKey=35983ecb-bd74-4b27-bdd5-2eb948587e04&Step=1&CommunityKey=336bb81c-ac97-46d5-95bb-319e41258fbe&ReturnUrl=%2fcommunity%2fuser%2fibmz-and-linuxone%2fviewdocument%2faccelerator-dependency-based-buil%3fCommunityKey%3df461c55d-159c-4a94-b708-9f7fe11d972b%26tab%3dlibrarydocuments"
+                                class="ibm-btn-pri ibm-btn-teal-50"
+                                >Learn more</a
+                              >
+                            </p>
+                          </div>
+                        </div>
+                      </div>
+                      <div class="card-equal ibm-col-12-4 ibm-col-medium-12-6 ibm-col-sm-12-12">
+                        <div class="ibm-card" style="height: 250px;">
+                          <div class="ibm-card__content">
+                            <h3 class="ibm-h3">ADFz Learning Resources</h3>
+                            <p>Training, Video and Blog Resources</p>
+                          </div>
+                          <div class="ibm-card__bottom">
+                            <p class="ibm-btn-row">
+                              <a
+                                href="adfz-learning-resources.html"
+                                class="ibm-btn-pri ibm-btn-teal-50"
+                                >Learn more</a
+                              >
+                            </p>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <!-- tileend -->
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- 
+<div class="">
+    <div class="ibm-fluid ibm-padding-bottom-r1 ibm-padding-top-r1">
+        <div>
+            <div class="ibm-col-12-3 ibm-col-medium-12-12">
+                <h2 class="ibm-h2 ibm-padding-top-0 ibm-padding-bottom-1 ibm-textcolor-blue-50">Whitepapers</h2>
+            </div>
+            <div class="ibm-col-12-9 ibm-col-medium-12-12 ">
+                <div class="ibm-textcolor-default ibm-padding-top-0 ibm-padding-bottom-0">
+
+                    <div class="ibm-columns ibm-fluid" data-items=".ibm-card" data-widget="setsameheight">
+
+                        <div class="ibm-col-12-4 ibm-col-medium-12-6 ibm-col-sm-12-12">
+                            <div class="ibm-card">
+                                <div class="ibm-card__image">
+                             
+                                </div>
+                                <div class="ibm-card__content">
+                                    <h3 class="ibm-h3">The right offerings and strategy for the Internet of Things
+                                    </h3>
+                                    <p>IBM is named a leader in The Forrester Wave: loT Software Platforms, Q4 2016
+                                    </p>
+                                    <p class="ibm-btn-row">
+                                        <a href="javascript:;" class="ibm-btn-pri ibm-btn-teal-50">Learn more</a>
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="ibm-col-12-4 ibm-col-medium-12-6 ibm-col-sm-12-12">
+                            <div class="ibm-card">
+                                <div class="ibm-card__image">
+                      
+                                </div>
+                                <div class="ibm-card__content">
+                                    <h3 class="ibm-h3">Move to the cloud and reap the financial benefit</h3>
+                                    <p>With POWER8 servers, you can process big data and analytics workloads in the
+                                        cloud – and reduce costs</p>
+                                    <p class="ibm-btn-row">
+                                        <a href="javascript:;" class="ibm-btn-pri ibm-btn-teal-50">Learn more</a>
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="ibm-col-12-4 ibm-col-medium-12-6 ibm-col-sm-12-12">
+                            <div class="ibm-card">
+                                <div class="ibm-card__image">
+                   
+                                </div>
+                                <div class="ibm-card__content">
+                                    <h3 class="ibm-h3">Move to the cloud and reap the financial benefit</h3>
+                                    <p>With POWER8 servers, you can process big data and analytics workloads in the
+                                        cloud – and reduce costs</p>
+                                    <p class="ibm-btn-row">
+                                        <a href="javascript:;" class="ibm-btn-pri ibm-btn-teal-50">Learn more</a>
+                                    </p>
+                                </div>
+
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div> -->
           <!-- Page Content -->
         </div>
         <!-- #content -->
@@ -1483,7 +1592,7 @@
         <a
           class="ibm-nospacing ibm-top-link"
           aria-label="Back to top"
-          href="https://developer.ibm.com/mainframe/products/devops-acceleration-program/training/dbb-self-paced-learning/#top"
+          href="https://developer.ibm.com/mainframe/products/devops-acceleration-program/training/#top"
           tabindex="0"
           >Back to top</a
         >
@@ -1495,6 +1604,32 @@
           <div class="ibm-columns ibm-padding-bottom-0"></div>
         </div>
       </footer>
+    </div>
+
+    <div class="ibm-band ibm-band ibm-background-cool-gray-80 ibm-textcolor-white-core">
+      <div class="ibm-fluid ibm-padding-bottom-r1 ibm-padding-top-1">
+        <div>
+          <div class="ibm-col-12-3 ibm-col-medium-12-12 ">
+            <h2 id="contactus" class="ibm-h2 ibm-padding-top-1 ibm-padding-bottom-1 ibm-textcolor-white-core">
+              Contact us
+            </h2>
+          </div>
+          <div class="ibm-col-12-9 ibm-col-medium-12-12 ">
+            <div class="ibm-textcolor-white-core ibm-padding-top-1 ibm-padding-bottom-0 ibm-pull-quote ibm-h3 ">
+              <p>
+                If you have any questions or inquiries regarding the
+                DevOps Acceleration Program, please feel free to contact
+                the
+                <strong>
+                  <a style="color:white;text-decoration:underline;" href="mailto:dat@ibm.com">
+                    DevOps Acceleration Team
+                  </a>
+                </strong>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
     <!-- #page -->
 
@@ -1519,7 +1654,7 @@
           /><input
             type="hidden"
             name="_wp_http_referer"
-            value="/mainframe/products/devops-acceleration-program/training/dbb-self-paced-learning/"
+            value="/mainframe/products/devops-acceleration-program/training/"
           />
           <header>
             <div class="gdpr-box-title">
@@ -1608,27 +1743,24 @@
     </script>
     <script
       type="text/javascript"
-      src="./dbb-self-paced-learning_files/navigation.js"
+      src="./Training_files/navigation.js"
     ></script>
     <script
       type="text/javascript"
-      src="./dbb-self-paced-learning_files/skip-link-focus-fix.js"
+      src="./Training_files/skip-link-focus-fix.js"
+    ></script>
+    <script type="text/javascript" src="./Training_files/tactic.js"></script>
+    <script
+      type="text/javascript"
+      src="./Training_files/tacticbindlinks.js"
     ></script>
     <script
       type="text/javascript"
-      src="./dbb-self-paced-learning_files/tactic.js"
+      src="./Training_files/new-tab.min.js"
     ></script>
     <script
       type="text/javascript"
-      src="./dbb-self-paced-learning_files/tacticbindlinks.js"
-    ></script>
-    <script
-      type="text/javascript"
-      src="./dbb-self-paced-learning_files/new-tab.min.js"
-    ></script>
-    <script
-      type="text/javascript"
-      src="./dbb-self-paced-learning_files/wp-embed.min.js"
+      src="./Training_files/wp-embed.min.js"
     ></script>
 
     <script>
@@ -1649,12 +1781,12 @@
           {
             title: "Sign In",
             url:
-              "https://developer.ibm.com/sso/login?d=https%3A%2F%2Fdeveloper.ibm.com%2Fmainframe%2Fproducts%2Fdevops-acceleration-program%2Ftraining%2Fdbb-self-paced-learning&lang=en_US",
+              "https://developer.ibm.com/sso/login?d=https%3A%2F%2Fdeveloper.ibm.com%2Fmainframe%2Fproducts%2Fdevops-acceleration-program%2Ftraining&lang=en_US",
           },
           {
             title: "Register",
             url:
-              "https://developer.ibm.com/sso/register?lang=en_US&d=https%3A%2F%2Fdeveloper.ibm.com%2Fmainframe%2Fproducts%2Fdevops-acceleration-program%2Ftraining%2Fdbb-self-paced-learning",
+              "https://developer.ibm.com/sso/register?lang=en_US&d=https%3A%2F%2Fdeveloper.ibm.com%2Fmainframe%2Fproducts%2Fdevops-acceleration-program%2Ftraining",
           },
         ];
         changeMenu(userLinks);
@@ -1765,7 +1897,7 @@
         <div class="pn-modal-bd"></div>
         <div class="pn-modal-ft"></div>
         <a
-          href="https://developer.ibm.com/mainframe/products/devops-acceleration-program/training/dbb-self-paced-learning/#"
+          href="https://developer.ibm.com/mainframe/products/devops-acceleration-program/training/#"
           class="pn-modal-close"
           >x</a
         >

--- a/Training/Training.html
+++ b/Training/Training.html
@@ -1,105 +1,90 @@
 <!DOCTYPE html>
 <!-- saved from url=(0082)https://developer.ibm.com/mainframe/products/devops-acceleration-program/training/ -->
-<html
-  lang="en-US"
-  prefix="og: http://ogp.me/ns#"
-  style=""
-  class="applicationcache geolocation history postmessage svg websockets localstorage sessionstorage websqldatabase webworkers hashchange pointerevents canvas audio canvastext video webgl cssgradients multiplebgs opacity rgba inlinesvg hsla supports svgclippaths smil no-touchevents fontface generatedcontent textshadow cssanimations backgroundsize borderimage borderradius boxshadow csscolumns csscolumns-width csscolumns-span csscolumns-fill csscolumns-gap csscolumns-rule csscolumns-rulecolor csscolumns-rulestyle csscolumns-rulewidth csscolumns-breakbefore csscolumns-breakafter csscolumns-breakinside flexbox flexboxlegacy cssreflections csstransforms csstransforms3d csstransitions indexeddb indexeddb-deletedatabase js ibm-v18 ibm-cxtype-4g hires mac chrome chrome8 webkit webkit5 ibm-grid-xlarge"
->
-  <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-    <!-- SITE MON : START (DO NOT DELETE) -->
-    <!-- developerWorks monitoring token -->
-    <!-- SITE MON : END (DO NOT DELETE) -->
+<html lang="en-US" prefix="og: http://ogp.me/ns#" style=""
+  class="applicationcache geolocation history postmessage svg websockets localstorage sessionstorage websqldatabase webworkers hashchange pointerevents canvas audio canvastext video webgl cssgradients multiplebgs opacity rgba inlinesvg hsla supports svgclippaths smil no-touchevents fontface generatedcontent textshadow cssanimations backgroundsize borderimage borderradius boxshadow csscolumns csscolumns-width csscolumns-span csscolumns-fill csscolumns-gap csscolumns-rule csscolumns-rulecolor csscolumns-rulestyle csscolumns-rulewidth csscolumns-breakbefore csscolumns-breakafter csscolumns-breakinside flexbox flexboxlegacy cssreflections csstransforms csstransforms3d csstransitions indexeddb indexeddb-deletedatabase js ibm-v18 ibm-cxtype-4g hires mac chrome chrome8 webkit webkit5 ibm-grid-xlarge">
 
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <!-- v18 meta -->
-    <meta name="geo.country" content="ZZ" />
-    <meta name="dcterms.rights" content="� Copyright IBM Corp. 2016" />
-    <meta name="dcterms.date" content="2016-07-18" />
-    <meta name="keywords" content="" />
-    <meta name="robots" content="index, follow" />
-    <link rel="shortcut icon" href="https://www.ibm.com/favicon.ico" />
+<head>
+  <meta http-equiv="refresh" content="2;url=https://ibm.github.io/mainframe-downloads/Training/courses.html" />
+  <!-- SITE MON : START (DO NOT DELETE) -->
+  <!-- developerWorks monitoring token -->
+  <!-- SITE MON : END (DO NOT DELETE) -->
 
-    <!-- end of v18 meta -->
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <!-- v18 meta -->
+  <meta name="geo.country" content="ZZ" />
+  <meta name="dcterms.rights" content="� Copyright IBM Corp. 2016" />
+  <meta name="dcterms.date" content="2016-07-18" />
+  <meta name="keywords" content="" />
+  <meta name="robots" content="index, follow" />
+  <link rel="shortcut icon" href="https://www.ibm.com/favicon.ico" />
 
-    <link rel="profile" href="http://gmpg.org/xfn/11" />
-    <link
-      rel="pingback"
-      href="https://developer.ibm.com/mainframe/xmlrpc.php"
-    />
-    <script>
-      digitalData = {
-        page: {
-          category: {
-            primaryCategory: "SOFDCMFDZZ",
-            ibm: [],
-          },
-          pageInfo: {
-            effectiveDate: "2016-07-18",
-            expiryDate: "2020-07-18",
-            language: "en-US",
-            publishDate: "2019-05-07",
-            publisher: "IBM Corporation",
-            version: "v18",
-            pageID: "",
-            ibm: {
-              contentDelivery: "HTML",
-              contentProducer: "IBM Northstar Template Generator 2.0",
-              country: "ZZ",
-              industry: "ZZ",
-              owner: "Jamie Pickett\/Boulder\/IBM",
-              siteID: "DWNEXT",
-              subject: "SW700",
-              type: "SW700",
-              cmClientID: "50200000| DWNEXT",
-              encoding: "utf8",
-              encodingRaw: "utf-8",
-              title: "Mainframe DEV",
-              contentType: "page",
-              wpid: "46",
-              topics: "",
-              contentArea: "",
-            },
-            metrics: [],
-            keywords: "",
-            description:
-              "Mainframe DEV - Enterprise Modernization and Mainframe Development",
-          },
-          attributes: [],
+  <!-- end of v18 meta -->
+
+  <link rel="profile" href="http://gmpg.org/xfn/11" />
+  <link rel="pingback" href="https://developer.ibm.com/mainframe/xmlrpc.php" />
+  <script>
+    digitalData = {
+      page: {
+        category: {
+          primaryCategory: "SOFDCMFDZZ",
+          ibm: [],
         },
-        event_coordinator: [],
-        isLoaded: true,
-        user: {
-          profile: [],
-          segment: {},
+        pageInfo: {
+          effectiveDate: "2016-07-18",
+          expiryDate: "2020-07-18",
+          language: "en-US",
+          publishDate: "2019-05-07",
+          publisher: "IBM Corporation",
+          version: "v18",
+          pageID: "",
+          ibm: {
+            contentDelivery: "HTML",
+            contentProducer: "IBM Northstar Template Generator 2.0",
+            country: "ZZ",
+            industry: "ZZ",
+            owner: "Jamie Pickett\/Boulder\/IBM",
+            siteID: "DWNEXT",
+            subject: "SW700",
+            type: "SW700",
+            cmClientID: "50200000| DWNEXT",
+            encoding: "utf8",
+            encodingRaw: "utf-8",
+            title: "Mainframe DEV",
+            contentType: "page",
+            wpid: "46",
+            topics: "",
+            contentArea: "",
+          },
+          metrics: [],
+          keywords: "",
+          description:
+            "Mainframe DEV - Enterprise Modernization and Mainframe Development",
         },
-      };
-    </script>
-    <title>Training - Mainframe DEV</title>
+        attributes: [],
+      },
+      event_coordinator: [],
+      isLoaded: true,
+      user: {
+        profile: [],
+        segment: {},
+      },
+    };
+  </script>
+  <title>Training - Mainframe DEV</title>
 
-    <!-- This site is optimized with the Yoast SEO plugin v9.0.2 - https://yoast.com/wordpress/plugins/seo/ -->
-    <meta
-      name="description"
-      content="Our learning catalog offers you the training you need, featuring on-demand courses and live remote instructor-led training."
-    />
-    <link
-      rel="canonical"
-      href="https://developer.ibm.com/mainframe/products/devops-acceleration-program/training/"
-    />
-    <meta property="og:locale" content="en_US" />
-    <meta property="og:type" content="article" />
-    <meta property="og:title" content="Training - Mainframe DEV" />
-    <meta
-      property="og:description"
-      content="Our learning catalog offers you the training you need, featuring on-demand courses and live remote instructor-led training."
-    />
-    <meta
-      property="og:url"
-      content="https://developer.ibm.com/mainframe/products/devops-acceleration-program/training/"
-    />
-    <meta property="og:site_name" content="Mainframe DEV" />
-    <script type="application/ld+json">
+  <!-- This site is optimized with the Yoast SEO plugin v9.0.2 - https://yoast.com/wordpress/plugins/seo/ -->
+  <meta name="description"
+    content="Our learning catalog offers you the training you need, featuring on-demand courses and live remote instructor-led training." />
+  <link rel="canonical" href="https://developer.ibm.com/mainframe/products/devops-acceleration-program/training/" />
+  <meta property="og:locale" content="en_US" />
+  <meta property="og:type" content="article" />
+  <meta property="og:title" content="Training - Mainframe DEV" />
+  <meta property="og:description"
+    content="Our learning catalog offers you the training you need, featuring on-demand courses and live remote instructor-led training." />
+  <meta property="og:url"
+    content="https://developer.ibm.com/mainframe/products/devops-acceleration-program/training/" />
+  <meta property="og:site_name" content="Mainframe DEV" />
+  <script type="application/ld+json">
       {
         "@context": "https:\/\/schema.org",
         "@type": "Organization",
@@ -110,7 +95,7 @@
         "logo": ""
       }
     </script>
-    <script type="application/ld+json">
+  <script type="application/ld+json">
       {
         "@context": "https:\/\/schema.org",
         "@type": "BreadcrumbList",
@@ -150,1759 +135,975 @@
         ]
       }
     </script>
-    <!-- / Yoast SEO plugin. -->
+  <!-- / Yoast SEO plugin. -->
 
-    <link rel="dns-prefetch" href="https://1.www.s81c.com/" />
-    <link rel="dns-prefetch" href="https://www.ibm.com/" />
-    <link rel="dns-prefetch" href="https://s.w.org/" />
-    <link
-      rel="alternate"
-      type="application/rss+xml"
-      title="Mainframe DEV » Feed"
-      href="https://developer.ibm.com/mainframe/feed/"
-    />
-    <link
-      rel="alternate"
-      type="application/rss+xml"
-      title="Mainframe DEV » Comments Feed"
-      href="https://developer.ibm.com/mainframe/comments/feed/"
-    />
-    <meta
-      name="segment"
-      property="developerWorks (developerWorks)"
-      producttitle="developerWorks"
-      value="Mainframe DEV (developerWorks)"
-    />
-    <script type="text/javascript">
-      window._wpemojiSettings = {
-        baseUrl: "https:\/\/s.w.org\/images\/core\/emoji\/11\/72x72\/",
-        ext: ".png",
-        svgUrl: "https:\/\/s.w.org\/images\/core\/emoji\/11\/svg\/",
-        svgExt: ".svg",
-        source: {
-          concatemoji:
-            "\/\/dw1.s81c.com\/dw\/wp-includes\/js\/wp-emoji-release.min.js",
-        },
-      };
-      !(function(a, b, c) {
-        function d(a, b) {
-          var c = String.fromCharCode;
-          l.clearRect(0, 0, k.width, k.height),
-            l.fillText(c.apply(this, a), 0, 0);
-          var d = k.toDataURL();
-          l.clearRect(0, 0, k.width, k.height),
-            l.fillText(c.apply(this, b), 0, 0);
-          var e = k.toDataURL();
-          return d === e;
-        }
-        function e(a) {
-          var b;
-          if (!l || !l.fillText) return !1;
-          switch (((l.textBaseline = "top"), (l.font = "600 32px Arial"), a)) {
-            case "flag":
-              return (
-                !(b = d(
-                  [55356, 56826, 55356, 56819],
-                  [55356, 56826, 8203, 55356, 56819]
-                )) &&
-                ((b = d(
-                  [
-                    55356,
-                    57332,
-                    56128,
-                    56423,
-                    56128,
-                    56418,
-                    56128,
-                    56421,
-                    56128,
-                    56430,
-                    56128,
-                    56423,
-                    56128,
-                    56447,
-                  ],
-                  [
-                    55356,
-                    57332,
-                    8203,
-                    56128,
-                    56423,
-                    8203,
-                    56128,
-                    56418,
-                    8203,
-                    56128,
-                    56421,
-                    8203,
-                    56128,
-                    56430,
-                    8203,
-                    56128,
-                    56423,
-                    8203,
-                    56128,
-                    56447,
-                  ]
-                )),
+  <link rel="dns-prefetch" href="https://1.www.s81c.com/" />
+  <link rel="dns-prefetch" href="https://www.ibm.com/" />
+  <link rel="dns-prefetch" href="https://s.w.org/" />
+  <link rel="alternate" type="application/rss+xml" title="Mainframe DEV » Feed"
+    href="https://developer.ibm.com/mainframe/feed/" />
+  <link rel="alternate" type="application/rss+xml" title="Mainframe DEV » Comments Feed"
+    href="https://developer.ibm.com/mainframe/comments/feed/" />
+  <meta name="segment" property="developerWorks (developerWorks)" producttitle="developerWorks"
+    value="Mainframe DEV (developerWorks)" />
+  <script type="text/javascript">
+    window._wpemojiSettings = {
+      baseUrl: "https:\/\/s.w.org\/images\/core\/emoji\/11\/72x72\/",
+      ext: ".png",
+      svgUrl: "https:\/\/s.w.org\/images\/core\/emoji\/11\/svg\/",
+      svgExt: ".svg",
+      source: {
+        concatemoji:
+          "\/\/dw1.s81c.com\/dw\/wp-includes\/js\/wp-emoji-release.min.js",
+      },
+    };
+    !(function (a, b, c) {
+      function d(a, b) {
+        var c = String.fromCharCode;
+        l.clearRect(0, 0, k.width, k.height),
+          l.fillText(c.apply(this, a), 0, 0);
+        var d = k.toDataURL();
+        l.clearRect(0, 0, k.width, k.height),
+          l.fillText(c.apply(this, b), 0, 0);
+        var e = k.toDataURL();
+        return d === e;
+      }
+      function e(a) {
+        var b;
+        if (!l || !l.fillText) return !1;
+        switch (((l.textBaseline = "top"), (l.font = "600 32px Arial"), a)) {
+          case "flag":
+            return (
+              !(b = d(
+                [55356, 56826, 55356, 56819],
+                [55356, 56826, 8203, 55356, 56819]
+              )) &&
+              ((b = d(
+                [
+                  55356,
+                  57332,
+                  56128,
+                  56423,
+                  56128,
+                  56418,
+                  56128,
+                  56421,
+                  56128,
+                  56430,
+                  56128,
+                  56423,
+                  56128,
+                  56447,
+                ],
+                [
+                  55356,
+                  57332,
+                  8203,
+                  56128,
+                  56423,
+                  8203,
+                  56128,
+                  56418,
+                  8203,
+                  56128,
+                  56421,
+                  8203,
+                  56128,
+                  56430,
+                  8203,
+                  56128,
+                  56423,
+                  8203,
+                  56128,
+                  56447,
+                ]
+              )),
                 !b)
-              );
-            case "emoji":
-              return (
-                (b = d(
-                  [55358, 56760, 9792, 65039],
-                  [55358, 56760, 8203, 9792, 65039]
-                )),
-                !b
-              );
-          }
-          return !1;
+            );
+          case "emoji":
+            return (
+              (b = d(
+                [55358, 56760, 9792, 65039],
+                [55358, 56760, 8203, 9792, 65039]
+              )),
+              !b
+            );
         }
-        function f(a) {
-          var c = b.createElement("script");
-          (c.src = a),
-            (c.defer = c.type = "text/javascript"),
-            b.getElementsByTagName("head")[0].appendChild(c);
-        }
-        var g,
-          h,
-          i,
-          j,
-          k = b.createElement("canvas"),
-          l = k.getContext && k.getContext("2d");
-        for (
-          j = Array("flag", "emoji"),
-            c.supports = { everything: !0, everythingExceptFlag: !0 },
-            i = 0;
-          i < j.length;
-          i++
-        )
-          (c.supports[j[i]] = e(j[i])),
-            (c.supports.everything = c.supports.everything && c.supports[j[i]]),
-            "flag" !== j[i] &&
-              (c.supports.everythingExceptFlag =
-                c.supports.everythingExceptFlag && c.supports[j[i]]);
-        (c.supports.everythingExceptFlag =
-          c.supports.everythingExceptFlag && !c.supports.flag),
-          (c.DOMReady = !1),
-          (c.readyCallback = function() {
-            c.DOMReady = !0;
-          }),
-          c.supports.everything ||
-            ((h = function() {
-              c.readyCallback();
-            }),
-            b.addEventListener
-              ? (b.addEventListener("DOMContentLoaded", h, !1),
-                a.addEventListener("load", h, !1))
-              : (a.attachEvent("onload", h),
-                b.attachEvent("onreadystatechange", function() {
-                  "complete" === b.readyState && c.readyCallback();
-                })),
-            (g = c.source || {}),
-            g.concatemoji
-              ? f(g.concatemoji)
-              : g.wpemoji && g.twemoji && (f(g.twemoji), f(g.wpemoji)));
-      })(window, document, window._wpemojiSettings);
-    </script>
-    <script
-      src="./Training_files/wp-emoji-release.min.js"
-      type="text/javascript"
-      defer=""
-    ></script>
-    <style type="text/css">
-      img.wp-smiley,
-      img.emoji {
-        display: inline !important;
-        border: none !important;
-        box-shadow: none !important;
-        height: 1em !important;
-        width: 1em !important;
-        margin: 0 0.07em !important;
-        vertical-align: -0.1em !important;
-        background: none !important;
-        padding: 0 !important;
+        return !1;
       }
-    </style>
-    <link
-      rel="stylesheet"
-      id="gdpr-css"
-      href="./Training_files/gdpr-public.css"
-      type="text/css"
-      media="all"
-    />
-    <link
-      rel="stylesheet"
-      id="tab-styles-css"
-      href="./Training_files/tab-styles.css"
-      type="text/css"
-      media="all"
-    />
-    <link
-      rel="stylesheet"
-      id="home-v17-styles-css"
-      href="./Training_files/home.css"
-      type="text/css"
-      media="all"
-    />
-    <link
-      rel="stylesheet"
-      id="rotatingtweets-css"
-      href="./Training_files/style.css"
-      type="text/css"
-      media="all"
-    />
-    <link
-      rel="stylesheet"
-      id="dwboomer-style-css"
-      href="./Training_files/style(1).css"
-      type="text/css"
-      media="all"
-    />
-    <link
-      rel="stylesheet"
-      id="dashicons-css"
-      href="./Training_files/dashicons.min.css"
-      type="text/css"
-      media="all"
-    />
-    <link
-      rel="stylesheet"
-      id="pagepost_css-css"
-      href="./Training_files/pagepost.css"
-      type="text/css"
-      media="all"
-    />
-    <style id="pagepost_css-inline-css" type="text/css">
-      .site-content {
-        padding-top: 0 !important;
+      function f(a) {
+        var c = b.createElement("script");
+        (c.src = a),
+          (c.defer = c.type = "text/javascript"),
+          b.getElementsByTagName("head")[0].appendChild(c);
       }
-    </style>
-    <link
-      rel="stylesheet"
-      id="pnext.utils-css"
-      href="./Training_files/pnext.utils.css"
-      type="text/css"
-      media="all"
-    />
-    <script type="text/javascript" src="./Training_files/www.js"></script>
-    <style></style>
-    <script
-      type="text/javascript"
-      src="./Training_files/jquery.cycle.all.min.js"
-    ></script>
-    <script
-      type="text/javascript"
-      src="./Training_files/rotating_tweet.js"
-    ></script>
-    <script type="text/javascript" src="./Training_files/dyntabs.js"></script>
-    <script type="text/javascript" src="./Training_files/masonry.js"></script>
-    <script type="text/javascript">
-      /* <![CDATA[ */
-      var GDPR = {
-        ajaxurl:
-          "https:\/\/developer.ibm.com\/mainframe\/wp-admin\/admin-ajax.php",
-        aborting: "Aborting",
-        is_user_logged_in: "",
-        privacy_page_id: "0",
-      };
-      /* ]]> */
-    </script>
-    <script
-      type="text/javascript"
-      src="./Training_files/gdpr-public.js"
-    ></script>
-    <script
-      type="text/javascript"
-      src="./Training_files/tab-dropdown.js"
-    ></script>
-    <script type="text/javascript" src="./Training_files/mainframe.js"></script>
-    <script
-      type="text/javascript"
-      src="./Training_files/pnext.utils.js"
-    ></script>
-    <script type="text/javascript" src="./Training_files/ida_stats.js"></script>
-    <link
-      rel="https://api.w.org/"
-      href="https://developer.ibm.com/mainframe/wp-json/"
-    />
-    <link
-      rel="EditURI"
-      type="application/rsd+xml"
-      title="RSD"
-      href="https://developer.ibm.com/mainframe/xmlrpc.php?rsd"
-    />
-    <link
-      rel="wlwmanifest"
-      type="application/wlwmanifest+xml"
-      href="https://developer.ibm.com/mainframe/wp-includes/wlwmanifest.xml"
-    />
-    <meta name="generator" content="WordPress 4.9.9" />
-    <link rel="shortlink" href="https://developer.ibm.com/mainframe/?p=16082" />
-    <link
-      rel="alternate"
-      type="application/json+oembed"
-      href="https://developer.ibm.com/mainframe/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fdeveloper.ibm.com%2Fmainframe%2Fproducts%2Fdevops-acceleration-program%2Ftraining%2F"
-    />
-    <link
-      rel="alternate"
-      type="text/xml+oembed"
-      href="https://developer.ibm.com/mainframe/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fdeveloper.ibm.com%2Fmainframe%2Fproducts%2Fdevops-acceleration-program%2Ftraining%2F&amp;format=xml"
-    />
+      var g,
+        h,
+        i,
+        j,
+        k = b.createElement("canvas"),
+        l = k.getContext && k.getContext("2d");
+      for (
+        j = Array("flag", "emoji"),
+        c.supports = { everything: !0, everythingExceptFlag: !0 },
+        i = 0;
+        i < j.length;
+        i++
+      )
+        (c.supports[j[i]] = e(j[i])),
+          (c.supports.everything = c.supports.everything && c.supports[j[i]]),
+          "flag" !== j[i] &&
+          (c.supports.everythingExceptFlag =
+            c.supports.everythingExceptFlag && c.supports[j[i]]);
+      (c.supports.everythingExceptFlag =
+        c.supports.everythingExceptFlag && !c.supports.flag),
+        (c.DOMReady = !1),
+        (c.readyCallback = function () {
+          c.DOMReady = !0;
+        }),
+        c.supports.everything ||
+        ((h = function () {
+          c.readyCallback();
+        }),
+          b.addEventListener
+            ? (b.addEventListener("DOMContentLoaded", h, !1),
+              a.addEventListener("load", h, !1))
+            : (a.attachEvent("onload", h),
+              b.attachEvent("onreadystatechange", function () {
+                "complete" === b.readyState && c.readyCallback();
+              })),
+          (g = c.source || {}),
+          g.concatemoji
+            ? f(g.concatemoji)
+            : g.wpemoji && g.twemoji && (f(g.twemoji), f(g.wpemoji)));
+    })(window, document, window._wpemojiSettings);
+  </script>
+  <script src="./Training_files/wp-emoji-release.min.js" type="text/javascript" defer=""></script>
+  <style type="text/css">
+    img.wp-smiley,
+    img.emoji {
+      display: inline !important;
+      border: none !important;
+      box-shadow: none !important;
+      height: 1em !important;
+      width: 1em !important;
+      margin: 0 0.07em !important;
+      vertical-align: -0.1em !important;
+      background: none !important;
+      padding: 0 !important;
+    }
+  </style>
+  <link rel="stylesheet" id="gdpr-css" href="./Training_files/gdpr-public.css" type="text/css" media="all" />
+  <link rel="stylesheet" id="tab-styles-css" href="./Training_files/tab-styles.css" type="text/css" media="all" />
+  <link rel="stylesheet" id="home-v17-styles-css" href="./Training_files/home.css" type="text/css" media="all" />
+  <link rel="stylesheet" id="rotatingtweets-css" href="./Training_files/style.css" type="text/css" media="all" />
+  <link rel="stylesheet" id="dwboomer-style-css" href="./Training_files/style(1).css" type="text/css" media="all" />
+  <link rel="stylesheet" id="dashicons-css" href="./Training_files/dashicons.min.css" type="text/css" media="all" />
+  <link rel="stylesheet" id="pagepost_css-css" href="./Training_files/pagepost.css" type="text/css" media="all" />
+  <style id="pagepost_css-inline-css" type="text/css">
+    .site-content {
+      padding-top: 0 !important;
+    }
+  </style>
+  <link rel="stylesheet" id="pnext.utils-css" href="./Training_files/pnext.utils.css" type="text/css" media="all" />
+  <script type="text/javascript" src="./Training_files/www.js"></script>
+  <style></style>
+  <script type="text/javascript" src="./Training_files/jquery.cycle.all.min.js"></script>
+  <script type="text/javascript" src="./Training_files/rotating_tweet.js"></script>
+  <script type="text/javascript" src="./Training_files/dyntabs.js"></script>
+  <script type="text/javascript" src="./Training_files/masonry.js"></script>
+  <script type="text/javascript">
+    /* <![CDATA[ */
+    var GDPR = {
+      ajaxurl:
+        "https:\/\/developer.ibm.com\/mainframe\/wp-admin\/admin-ajax.php",
+      aborting: "Aborting",
+      is_user_logged_in: "",
+      privacy_page_id: "0",
+    };
+    /* ]]> */
+  </script>
+  <script type="text/javascript" src="./Training_files/gdpr-public.js"></script>
+  <script type="text/javascript" src="./Training_files/tab-dropdown.js"></script>
+  <script type="text/javascript" src="./Training_files/mainframe.js"></script>
+  <script type="text/javascript" src="./Training_files/pnext.utils.js"></script>
+  <script type="text/javascript" src="./Training_files/ida_stats.js"></script>
+  <link rel="https://api.w.org/" href="https://developer.ibm.com/mainframe/wp-json/" />
+  <link rel="EditURI" type="application/rsd+xml" title="RSD"
+    href="https://developer.ibm.com/mainframe/xmlrpc.php?rsd" />
+  <link rel="wlwmanifest" type="application/wlwmanifest+xml"
+    href="https://developer.ibm.com/mainframe/wp-includes/wlwmanifest.xml" />
+  <meta name="generator" content="WordPress 4.9.9" />
+  <link rel="shortlink" href="https://developer.ibm.com/mainframe/?p=16082" />
+  <link rel="alternate" type="application/json+oembed"
+    href="https://developer.ibm.com/mainframe/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fdeveloper.ibm.com%2Fmainframe%2Fproducts%2Fdevops-acceleration-program%2Ftraining%2F" />
+  <link rel="alternate" type="text/xml+oembed"
+    href="https://developer.ibm.com/mainframe/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fdeveloper.ibm.com%2Fmainframe%2Fproducts%2Fdevops-acceleration-program%2Ftraining%2F&amp;format=xml" />
 
-    <link href="./Training_files/www.css" rel="stylesheet" />
-    <link href="./Training_files/grid-fluid.css" rel="stylesheet" />
-    <link href="./Training_files/tables.css" rel="stylesheet" />
+  <link href="./Training_files/www.css" rel="stylesheet" />
+  <link href="./Training_files/grid-fluid.css" rel="stylesheet" />
+  <link href="./Training_files/tables.css" rel="stylesheet" />
 
-    <script type="text/javascript">
-      IBMCore.common.util.config.set({
-        masthead: {
-          type: "alternate",
+  <script type="text/javascript">
+    IBMCore.common.util.config.set({
+      masthead: {
+        type: "alternate",
+      },
+      greeting: { enabled: false },
+      footer: {
+        type: "alternate",
+        socialLinks: {
+          enabled: false,
         },
-        greeting: { enabled: false },
-        footer: {
-          type: "alternate",
-          socialLinks: {
-            enabled: false,
-          },
-        },
-        survey: { global_percent: 0 },
-      });
-    </script>
+      },
+      survey: { global_percent: 0 },
+    });
+  </script>
 
-    <script async="" src="./Training_files/aksb.min.js"></script>
-    <script>
-      var w = window;
-      if (
-        w.performance ||
-        w.mozPerformance ||
-        w.msPerformance ||
-        w.webkitPerformance
-      ) {
-        var d = document;
-        (AKSB = w.AKSB || {}),
-          (AKSB.q = AKSB.q || []),
-          (AKSB.mark =
-            AKSB.mark ||
-            function(e, _) {
-              AKSB.q.push(["mark", e, _ || new Date().getTime()]);
-            }),
-          (AKSB.measure =
-            AKSB.measure ||
-            function(e, _, t) {
-              AKSB.q.push(["measure", e, _, t || new Date().getTime()]);
-            }),
-          (AKSB.done =
-            AKSB.done ||
-            function(e) {
-              AKSB.q.push(["done", e]);
-            }),
-          AKSB.mark("firstbyte", new Date().getTime()),
-          (AKSB.prof = {
-            custid: "351329",
-            ustr: "",
-            originlat: "0",
-            clientrtt: "17",
-            ghostip: "184.84.243.148",
-            ipv6: false,
-            pct: "10",
-            clientip: "142.120.63.112",
-            requestid: "6b5240ef",
-            region: "24910",
-            protocol: "h2",
-            blver: 14,
-            akM: "x",
-            akN: "ae",
-            akTT: "O",
-            akTX: "1",
-            akTI: "6b5240ef",
-            ai: "335196",
-            ra: "false",
-            pmgn: "",
-            pmgi: "",
-            pmp: "",
-            qc: "",
+  <script async="" src="./Training_files/aksb.min.js"></script>
+  <script>
+    var w = window;
+    if (
+      w.performance ||
+      w.mozPerformance ||
+      w.msPerformance ||
+      w.webkitPerformance
+    ) {
+      var d = document;
+      (AKSB = w.AKSB || {}),
+        (AKSB.q = AKSB.q || []),
+        (AKSB.mark =
+          AKSB.mark ||
+          function (e, _) {
+            AKSB.q.push(["mark", e, _ || new Date().getTime()]);
           }),
-          (function(e) {
-            var _ = d.createElement("script");
-            (_.async = "async"), (_.src = e);
-            var t = d.getElementsByTagName("script"),
-              t = t[t.length - 1];
-            t.parentNode.insertBefore(_, t);
-          })(
-            ("https:" === d.location.protocol ? "https:" : "http:") +
-              "//ds-aksb-a.akamaihd.net/aksb.min.js"
-          );
+        (AKSB.measure =
+          AKSB.measure ||
+          function (e, _, t) {
+            AKSB.q.push(["measure", e, _, t || new Date().getTime()]);
+          }),
+        (AKSB.done =
+          AKSB.done ||
+          function (e) {
+            AKSB.q.push(["done", e]);
+          }),
+        AKSB.mark("firstbyte", new Date().getTime()),
+        (AKSB.prof = {
+          custid: "351329",
+          ustr: "",
+          originlat: "0",
+          clientrtt: "17",
+          ghostip: "184.84.243.148",
+          ipv6: false,
+          pct: "10",
+          clientip: "142.120.63.112",
+          requestid: "6b5240ef",
+          region: "24910",
+          protocol: "h2",
+          blver: 14,
+          akM: "x",
+          akN: "ae",
+          akTT: "O",
+          akTX: "1",
+          akTI: "6b5240ef",
+          ai: "335196",
+          ra: "false",
+          pmgn: "",
+          pmgi: "",
+          pmp: "",
+          qc: "",
+        }),
+        (function (e) {
+          var _ = d.createElement("script");
+          (_.async = "async"), (_.src = e);
+          var t = d.getElementsByTagName("script"),
+            t = t[t.length - 1];
+          t.parentNode.insertBefore(_, t);
+        })(
+          ("https:" === d.location.protocol ? "https:" : "http:") +
+          "//ds-aksb-a.akamaihd.net/aksb.min.js"
+        );
+    }
+  </script>
+  <style id="ibm-sitenav-menu-hidelinks">
+    @media screen and (max-width: 1075px) {
+      .ibm-sitenav-menu-container .ibm-sitenav-menu-list>ul>li {
+        display: none;
       }
-    </script>
-    <style id="ibm-sitenav-menu-hidelinks">
-      @media screen and (max-width: 1075px) {
-        .ibm-sitenav-menu-container .ibm-sitenav-menu-list > ul > li {
-          display: none;
-        }
-      }
-      @media screen and (min-width: 1076px) {
-        .ibm-mobilemenu-sitenavmenu > ul > li {
-          display: none;
-        }
-      }
-    </style>
-    <style id="ibm-masthead-hidelinks">
-      @media screen and (max-width: 457px) {
-        .ibm-masthead-categories,
-        #ibm-megamenu-sections {
-          display: none;
-        }
-      }
-    </style>
-  </head>
+    }
 
-  <body
-    id="ibm-com"
-    class="page-template page-template-page-templates page-template-empty page-template-page-templatesempty-php page page-id-16082 page-parent page-child parent-pageid-17162 ibm-com ibm-type group-blog ibm-sitenav-menu"
-  >
-    
-    <style>
-      .code_p_announcement .code_content__wrap {
-        background: #4178be;
-        position: relative;
-        overflow: hidden;
-        padding-right: 3rem;
+    @media screen and (min-width: 1076px) {
+      .ibm-mobilemenu-sitenavmenu>ul>li {
+        display: none;
       }
-      .code_p_announcement .code_content__wrap p {
-        display: table;
-        width: auto;
-        margin: 0 auto;
-        padding: 1rem 0.5rem;
-        color: #ffffff;
-        font-size: 0.875rem;
-        font-weight: 400;
-        line-height: 1.125rem;
-        letter-spacing: 0.16px;
-        word-break: break-word;
-        text-decoration: none;
-      }
-      .code_p_announcement .code_content__wrap p .ibm-btn-sec.ibm-btn-white {
-        margin-left: 0.5rem;
-        text-decoration: none;
-        padding: 0.75rem;
-        cursor: pointer;
-        font-size: 0.875rem;
-      }
-      .code_p_announcement .code_content__wrap .announce_link {
-        display: block;
-        text-decoration: none;
-        cursor: pointer;
-        padding: 1rem 0;
-      }
-    </style>
-    <div style="display:none">page-templates/empty.php</div>
-    <!--div id="page" class="site"-->
-    <div id="ibm-top" class="ibm-landing-page">
-      <a
-        class="skip-link screen-reader-text"
-        href="https://developer.ibm.com/mainframe/products/devops-acceleration-program/training/#main"
-        >Skip to content</a
-      >
+    }
+  </style>
+  <style id="ibm-masthead-hidelinks">
+    @media screen and (max-width: 457px) {
 
-      <!-- MASTHEAD_BEGIN -->
-      <div
-        id="ibm-masthead"
-        role="banner"
-        aria-label="IBM"
-        class="ibm-mhtype-minimal"
-      >
-        <div id="ibm-mast-options">
-          <ul role="toolbar" aria-labelledby="ibm-masthead">
-            <li id="ibm-geo" role="presentation">
-              <a href="http://www.ibm.com/planetwide/select/selector.html"
-                >United States</a
-              >
-            </li>
-          </ul>
+      .ibm-masthead-categories,
+      #ibm-megamenu-sections {
+        display: none;
+      }
+    }
+  </style>
+</head>
+
+<body id="ibm-com"
+  class="page-template page-template-page-templates page-template-empty page-template-page-templatesempty-php page page-id-16082 page-parent page-child parent-pageid-17162 ibm-com ibm-type group-blog ibm-sitenav-menu">
+
+  <style>
+    .code_p_announcement .code_content__wrap {
+      background: #4178be;
+      position: relative;
+      overflow: hidden;
+      padding-right: 3rem;
+    }
+
+    .code_p_announcement .code_content__wrap p {
+      display: table;
+      width: auto;
+      margin: 0 auto;
+      padding: 1rem 0.5rem;
+      color: #ffffff;
+      font-size: 0.875rem;
+      font-weight: 400;
+      line-height: 1.125rem;
+      letter-spacing: 0.16px;
+      word-break: break-word;
+      text-decoration: none;
+    }
+
+    .code_p_announcement .code_content__wrap p .ibm-btn-sec.ibm-btn-white {
+      margin-left: 0.5rem;
+      text-decoration: none;
+      padding: 0.75rem;
+      cursor: pointer;
+      font-size: 0.875rem;
+    }
+
+    .code_p_announcement .code_content__wrap .announce_link {
+      display: block;
+      text-decoration: none;
+      cursor: pointer;
+      padding: 1rem 0;
+    }
+  </style>
+  <div style="display:none">page-templates/empty.php</div>
+  <!--div id="page" class="site"-->
+  <div id="ibm-top" class="ibm-landing-page">
+    <a class="skip-link screen-reader-text"
+      href="https://developer.ibm.com/mainframe/products/devops-acceleration-program/training/#main">Skip to content</a>
+
+    <!-- MASTHEAD_BEGIN -->
+    <div id="ibm-masthead" role="banner" aria-label="IBM" class="ibm-mhtype-minimal">
+      <div id="ibm-mast-options">
+        <ul role="toolbar" aria-labelledby="ibm-masthead">
+          <li id="ibm-geo" role="presentation">
+            <a href="http://www.ibm.com/planetwide/select/selector.html">United States</a>
+          </li>
+        </ul>
+      </div>
+      <div id="ibm-universal-nav" class="">
+        <div id="ibm-home">
+          <a href="http://www.ibm.com/us-en/?lnk=m">IBM�</a>
         </div>
-        <div id="ibm-universal-nav" class="">
-          <div id="ibm-home">
-            <a href="http://www.ibm.com/us-en/?lnk=m">IBM�</a>
+      </div>
+    </div>
+
+    <div class="ibm-mobilemenu ibm-hide" id="ibm-burger-menu-container" aria-labelledby="ibm-burgermenu-a11y"
+      role="dialog" tabindex="0">
+      <p class="ibm-hide" id="ibm-burgermenu-a11y">Site navigation</p>
+      <div class="ibm-mobilemenu-close">
+        <p class="ibm-icononly ibm-fright ibm-ind-link ibm-nospacing">
+          <a class="ibm-close-link"
+            href="https://developer.ibm.com/mainframe/products/devops-acceleration-program/training/?lnk=hm#">Close</a>
+        </p>
+      </div>
+      <div class="ibm-mobilemenu-section ibm-mobilemenu-sitenavmenu">
+        <ul id="primary-menu" class="menu">
+          <li class="ibm-mobile-section-heading ibm-mobile-sitename">
+            <a href="https://developer.ibm.com/mainframe/?lnk=hm" rel="home">Mainframe DEV</a>
+          </li>
+          <li id="menu-item-1540" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-1540">
+            <a href="https://developer.ibm.com/mainframe?lnk=hm" tabindex="0">Home</a>
+          </li>
+          <li id="menu-item-4064" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-4064">
+            <a href="https://developer.ibm.com/mainframe/products/downloads/?lnk=hm" tabindex="-1">Downloads</a>
+          </li>
+          <li id="menu-item-16086"
+            class="menu-item menu-item-type-post_type menu-item-object-page current-menu-item page_item page-item-16082 current_page_item menu-item-16086">
+            <a href="https://developer.ibm.com/mainframe/products/devops-acceleration-program/training/?lnk=hm"
+              tabindex="-1">Training</a>
+          </li>
+          <li id="menu-item-14411"
+            class="menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-14411">
+            <a href="https://developer.ibm.com/mainframe/products/documentation/?lnk=hm" tabindex="-1">Documentation</a>
+            <ul class="sub-menu">
+              <li id="menu-item-14412" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-14412">
+                <a href="https://developer.ibm.com/mainframe/products/documentation/kc/?lnk=hm"><span>IBM KCCI
+                    (Local)</span></a>
+              </li>
+              <li id="menu-item-14413" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-14413">
+                <a href="https://www.ibm.com/support/knowledgecenter/?lnk=hm"><span>IBM Documentation</span></a>
+              </li>
+              <li id="menu-item-22185" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-22185">
+                <a
+                  href="https://developer.ibm.com/mainframe/products/host-configuration-assistant-for-z-development/?lnk=hm"><span>Host
+                    Configuration Assistant for Z Development</span></a>
+              </li>
+            </ul>
+          </li>
+          <li id="menu-item-31" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-31">
+            <a href="https://developer.ibm.com/mainframe/blog/?lnk=hm" tabindex="-1">Blogs</a>
+          </li>
+          <li id="menu-item-9254"
+            class="menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-9254">
+            <a href="https://developer.ibm.com/mainframe/announcements/?lnk=hm" tabindex="-1">Announcements</a>
+            <ul class="sub-menu">
+              <li id="menu-item-13727"
+                class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-13727">
+                <a
+                  href="https://developer.ibm.com/mainframe/category/announcements/release-notes/ibm-z-os-explorer-aqua/?lnk=hm"><span>Release
+                    notes for Aqua</span></a>
+              </li>
+            </ul>
+          </li>
+          <li id="menu-item-386" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-386">
+            <a href="https://developer.ibm.com/mainframe/events/?lnk=hm" tabindex="-1">Events</a>
+          </li>
+          <li id="menu-item-33" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-33">
+            <a href="https://developer.ibm.com/answers/smartspace/mainframe/?lnk=hm" tabindex="-1">Forum</a>
+          </li>
+          <li id="menu-item-51" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-51">
+            <a href="https://developer.ibm.com/mainframe/videos?lnk=hm" tabindex="-1">Videos</a>
+          </li>
+        </ul>
+      </div>
+      <div class="ibm-mobilemenu-section">
+        <ul class="ibm-mobilemenu-mhlinks" aria-label="Discover IBM">
+          <li>
+            <div data-widget="showhide" data-type="panel" class="ibm-show-hide ibm-widget-processed">
+              <h2>
+                <a href="javascript:void();">Products &amp; Solutions</a>
+              </h2>
+              <div class="ibm-container-body" style="display: none;">
+                <ul>
+                  <li>
+                    <a href="https://www.ibm.com/products?lnk=hmhpmps_bupr&amp;lnk2=link"><span>Top products &amp;
+                        platforms</span></a>
+                  </li>
+                  <li>
+                    <a href="https://www.ibm.com/industries?lnk=hmhpmps_buin&amp;lnk2=link"><span>Industries</span></a>
+                  </li>
+                  <li>
+                    <a href="https://www.ibm.com/artificial-intelligence?lnk=hmhpmps_buai&amp;lnk2=link"><span>Artificial
+                        intelligence</span></a>
+                  </li>
+                  <li>
+                    <a href="https://www.ibm.com/blockchain?lnk=hmhpmps_bubc&amp;lnk2=link"><span>Blockchain</span></a>
+                  </li>
+                  <li>
+                    <a href="https://www.ibm.com/automation?lnk=hmhpmps_buau&amp;lnk2=link"><span>Business
+                        automation</span></a>
+                  </li>
+                  <li>
+                    <a href="https://www.ibm.com/business-operations?lnk=hmhpmps_buop&amp;lnk2=link"><span>Business
+                        operations</span></a>
+                  </li>
+                  <li>
+                    <a href="https://www.ibm.com/cloud/products?lnk=hmhpmps_bucl&amp;lnk2=link"><span>Cloud
+                        computing</span></a>
+                  </li>
+                  <li>
+                    <a href="https://www.ibm.com/analytics?lnk=hmhpmps_buda&amp;lnk2=link"><span>Data &amp;
+                        Analytics</span></a>
+                  </li>
+                  <li>
+                    <a href="https://www.ibm.com/it-infrastructure/?lnk=hmhpmps_buit&amp;lnk2=link"><span>IT
+                        infrastructure</span></a>
+                  </li>
+                  <li>
+                    <a href="https://www.ibm.com/security?lnk=hmhpmps_buse&amp;lnk2=link"><span>Security</span></a>
+                  </li>
+                  <li>
+                    <a href="https://www.ibm.com/supply-chain?lnk=hmhpmps_busc&amp;lnk2=link"><span>Supply
+                        chain</span></a>
+                  </li>
+                  <li>
+                    <a href="https://www.ibm.com/financing?lnk=hmhpmps_bufi&amp;lnk2=link"><span>Payment plans for
+                        Products &amp; Solutions</span></a>
+                  </li>
+                  <li>
+                    <a href="https://www.ibm.com/products?lnk=hmhpmps_buall&amp;lnk2=link"><span>View all
+                        products</span></a>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </li>
+          <li>
+            <div data-widget="showhide" data-type="panel" class="ibm-show-hide ibm-widget-processed">
+              <h2>
+                <a href="javascript:void();">Services &amp; Consulting</a>
+              </h2>
+              <div class="ibm-container-body" style="display: none;">
+                <ul>
+                  <li>
+                    <a href="https://www.ibm.com/services/process?lnk=hmhpmsc_bups&amp;lnk2=link"><span>Business process
+                        services</span></a>
+                  </li>
+                  <li>
+                    <a href="https://www.ibm.com/services/ibmix/?lnk=hmhpmsc_budbs&amp;lnk2=link"><span>Design &amp;
+                        business strategy</span></a>
+                  </li>
+                  <li>
+                    <a href="https://www.ibm.com/services/?lnk=hmhpmsc_buhs&amp;lnk2=link"><span>Hybrid multicloud
+                        services</span></a>
+                  </li>
+                  <li>
+                    <a href="https://www.ibm.com/talent-management?lnk=hmhpmsc_buta&amp;lnk2=link"><span>Talent &amp;
+                        transformation</span></a>
+                  </li>
+                  <li>
+                    <a href="https://www.ibm.com/services/applications?lnk=hmhpmsc_buas&amp;lnk2=link"><span>Application
+                        services</span></a>
+                  </li>
+                  <li>
+                    <a href="https://www.ibm.com/security/services?lnk=hmhpmsc_buse&amp;lnk2=link"><span>Security
+                        services</span></a>
+                  </li>
+                  <li>
+                    <a href="https://www.ibm.com/services/technology-support?lnk=hmhpmsc_busv&amp;lnk2=link"><span>Services
+                        for tech support</span></a>
+                  </li>
+                  <li>
+                    <a
+                      href="https://www.ibm.com/financing/solutions/it-services-financing?lnk=hmhpmsc_bufi&amp;lnk2=link"><span>Payment
+                        plans for Services &amp; Consulting</span></a>
+                  </li>
+                  <li>
+                    <a href="https://www.ibm.com/services?lnk=hmhpmsc_buall&amp;lnk2=link"><span>View all
+                        services</span></a>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </li>
+          <li>
+            <div data-widget="showhide" data-type="panel" class="ibm-show-hide ibm-widget-processed">
+              <h2><a href="javascript:void();">Learn &amp; Support</a></h2>
+              <div class="ibm-container-body" style="display: none;">
+                <ul>
+                  <li>
+                    <a href="https://www.ibm.com/support?lnk=hmhpmls_busu&amp;lnk2=link"><span>Support</span></a>
+                  </li>
+                  <li>
+                    <a
+                      href="https://www.ibm.com/support/knowledgecenter/?lnk=hmhpmls_budc&amp;lnk2=link"><span>Documentation</span></a>
+                  </li>
+                  <li>
+                    <a href="https://developer.ibm.com/?lnk=hmhpmls_bude&amp;lnk2=link"><span>Developer
+                        education</span></a>
+                  </li>
+                  <li>
+                    <a href="https://www.ibm.com/training/?lnk=hmhpmls_butr&amp;lnk2=link"><span>Training</span></a>
+                  </li>
+                  <li>
+                    <a href="https://www.ibm.com/blogs/?lnk=hmhpmls_bure&amp;lnk2=link"><span>Resources</span></a>
+                  </li>
+                  <li>
+                    <a href="https://www.ibm.com/cloud/learn?lnk=hmhpmls_buwi&amp;lnk2=link"><span>What is...</span></a>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </li>
+          <li>
+            <div data-widget="showhide" data-type="panel" class="ibm-show-hide ibm-widget-processed">
+              <h2><a href="javascript:void();">Explore more</a></h2>
+              <div class="ibm-container-body" style="display: none;">
+                <ul>
+                  <li>
+                    <a
+                      href="https://www.ibm.com/partnerworld/public?lnk=hmhpmex_bupa&amp;lnk2=link"><span>Partners</span></a>
+                  </li>
+                  <li>
+                    <a href="https://www.research.ibm.com/?lnk=hmhpmex_bure&amp;lnk2=link"><span>IBM Research</span></a>
+                  </li>
+                  <li>
+                    <a href="https://www.ibm.com/ibm/us/en?lnk=hmhpmex_buab&amp;lnk2=link"><span>About IBM</span></a>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </li>
+          <li>
+            <div data-widget="showhide" data-type="panel" class="ibm-show-hide ibm-widget-processed">
+              <h2><a href="javascript:void();">COVID-19</a></h2>
+              <div class="ibm-container-body" style="display: none;">
+                <ul>
+                  <li>
+                    <a href="https://www.ibm.com/redirect-marketplace/impact/covid-19/business-solutions?lnk=hm"><span>Business
+                        solutions</span></a>
+                  </li>
+                  <li>
+                    <a href="https://www.ibm.com/redirect-marketplace/impact/covid-19/?lnk=hm"><span>Science and
+                        technology</span></a>
+                  </li>
+                  <li>
+                    <a href="https://newsroom.ibm.com/COVID-19?lnk=hmhpmcov_ns&amp;lnk2=link"><span>News and
+                        resources</span></a>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </li>
+        </ul>
+      </div>
+    </div>
+    <div class="ibm-mhplaceholder ibm-hide"></div>
+    <!-- MASTHEAD_END -->
+    <div id="ibm-content-wrapper">
+      <header role="banner" aria-labelledby="ibm-pagetitle-h1">
+        <!-- MASTHEAD_SITENAV_BEGIN -->
+        <div class="ibm-sitenav-menu-container" data-widgetprocessed="true">
+          <div class="ibm-sitenav-menu-list">
+            <ul id="primary-menu" class="menu">
+              <li id="menu-item-386" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-386">
+                <a href="../index.html" tabindex="-1">Home</a>
+              </li>
+              <li id="menu-item-4064"
+                class="menu-item menu-item-type-post_type menu-item-object-page page_item page-item-1533 menu-item-4064">
+                <a href="../downloads.html" tabindex="-1">Downloads</a>
+              </li>
+
+              <li id="menu-item-16086"
+                class="menu-item menu-item-type-post_type menu-item-object-page current-menu-item page_item page-item-16082 current_page_item menu-item-16086">
+                <a href="Training.html" tabindex="-1">Training</a>
+              </li>
+
+              <li id="menu-item-14411"
+                class="menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-14411">
+                <a href="https://www.ibm.com/docs/en/offline" tabindex="-1">Documentation</a>
+                <ul class="sub-menu">
+                  <li id="menu-item-14412"
+                    class="menu-item menu-item-type-post_type menu-item-object-page menu-item-14412">
+                    <a href="https://www.ibm.com/docs/en/offline">IBM Documentation Offline</a>
+                  </li>
+                  <li id="menu-item-14413"
+                    class="menu-item menu-item-type-custom menu-item-object-custom menu-item-14413">
+                    <a href="https://www.ibm.com/support/knowledgecenter/">IBM Documentation</a>
+                  </li>
+                  <li id="menu-item-22185"
+                    class="menu-item menu-item-type-post_type menu-item-object-page menu-item-22185">
+                    <a href="../host-configuration-assistant.html">Host Configuration Assistant for Z Development</a>
+                  </li>
+                </ul>
+              </li>
+
+              <li id="menu-item-devops-acceleration"
+                class="menu-item menu-item-type-post_type menu-item-object-page page_item">
+                <a href="../DevOps_Acceleration_Program/dap.html" tabindex="-1">DevOps Acceleration Program</a>
+              </li>
+            </ul>
           </div>
         </div>
-      </div>
-      
-      <div
-        class="ibm-mobilemenu ibm-hide"
-        id="ibm-burger-menu-container"
-        aria-labelledby="ibm-burgermenu-a11y"
-        role="dialog"
-        tabindex="0"
-      >
-        <p class="ibm-hide" id="ibm-burgermenu-a11y">Site navigation</p>
-        <div class="ibm-mobilemenu-close">
-          <p class="ibm-icononly ibm-fright ibm-ind-link ibm-nospacing">
-            <a
-              class="ibm-close-link"
-              href="https://developer.ibm.com/mainframe/products/devops-acceleration-program/training/?lnk=hm#"
-              >Close</a
-            >
-          </p>
-        </div>
-        <div class="ibm-mobilemenu-section ibm-mobilemenu-sitenavmenu">
-          <ul id="primary-menu" class="menu">
-            <li class="ibm-mobile-section-heading ibm-mobile-sitename">
-              <a href="https://developer.ibm.com/mainframe/?lnk=hm" rel="home"
-                >Mainframe DEV</a
-              >
-            </li>
-            <li
-              id="menu-item-1540"
-              class="menu-item menu-item-type-custom menu-item-object-custom menu-item-1540"
-            >
-              <a href="https://developer.ibm.com/mainframe?lnk=hm" tabindex="0"
-                >Home</a
-              >
-            </li>
-            <li
-              id="menu-item-4064"
-              class="menu-item menu-item-type-post_type menu-item-object-page menu-item-4064"
-            >
-              <a
-                href="https://developer.ibm.com/mainframe/products/downloads/?lnk=hm"
-                tabindex="-1"
-                >Downloads</a
-              >
-            </li>
-            <li
-              id="menu-item-16086"
-              class="menu-item menu-item-type-post_type menu-item-object-page current-menu-item page_item page-item-16082 current_page_item menu-item-16086"
-            >
-              <a
-                href="https://developer.ibm.com/mainframe/products/devops-acceleration-program/training/?lnk=hm"
-                tabindex="-1"
-                >Training</a
-              >
-            </li>
-            <li
-              id="menu-item-14411"
-              class="menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-14411"
-            >
-              <a
-                href="https://developer.ibm.com/mainframe/products/documentation/?lnk=hm"
-                tabindex="-1"
-                >Documentation</a
-              >
-              <ul class="sub-menu">
-                <li
-                  id="menu-item-14412"
-                  class="menu-item menu-item-type-post_type menu-item-object-page menu-item-14412"
-                >
-                  <a
-                    href="https://developer.ibm.com/mainframe/products/documentation/kc/?lnk=hm"
-                    ><span>IBM KCCI (Local)</span></a
-                  >
-                </li>
-                <li
-                  id="menu-item-14413"
-                  class="menu-item menu-item-type-custom menu-item-object-custom menu-item-14413"
-                >
-                  <a href="https://www.ibm.com/support/knowledgecenter/?lnk=hm"
-                    ><span>IBM Documentation</span></a
-                  >
-                </li>
-                <li
-                  id="menu-item-22185"
-                  class="menu-item menu-item-type-post_type menu-item-object-page menu-item-22185"
-                >
-                  <a
-                    href="https://developer.ibm.com/mainframe/products/host-configuration-assistant-for-z-development/?lnk=hm"
-                    ><span
-                      >Host Configuration Assistant for Z Development</span
-                    ></a
-                  >
-                </li>
-              </ul>
-            </li>
-            <li
-              id="menu-item-31"
-              class="menu-item menu-item-type-post_type menu-item-object-page menu-item-31"
-            >
-              <a
-                href="https://developer.ibm.com/mainframe/blog/?lnk=hm"
-                tabindex="-1"
-                >Blogs</a
-              >
-            </li>
-            <li
-              id="menu-item-9254"
-              class="menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-9254"
-            >
-              <a
-                href="https://developer.ibm.com/mainframe/announcements/?lnk=hm"
-                tabindex="-1"
-                >Announcements</a
-              >
-              <ul class="sub-menu">
-                <li
-                  id="menu-item-13727"
-                  class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-13727"
-                >
-                  <a
-                    href="https://developer.ibm.com/mainframe/category/announcements/release-notes/ibm-z-os-explorer-aqua/?lnk=hm"
-                    ><span>Release notes for Aqua</span></a
-                  >
-                </li>
-              </ul>
-            </li>
-            <li
-              id="menu-item-386"
-              class="menu-item menu-item-type-post_type menu-item-object-page menu-item-386"
-            >
-              <a
-                href="https://developer.ibm.com/mainframe/events/?lnk=hm"
-                tabindex="-1"
-                >Events</a
-              >
-            </li>
-            <li
-              id="menu-item-33"
-              class="menu-item menu-item-type-custom menu-item-object-custom menu-item-33"
-            >
-              <a
-                href="https://developer.ibm.com/answers/smartspace/mainframe/?lnk=hm"
-                tabindex="-1"
-                >Forum</a
-              >
-            </li>
-            <li
-              id="menu-item-51"
-              class="menu-item menu-item-type-custom menu-item-object-custom menu-item-51"
-            >
-              <a
-                href="https://developer.ibm.com/mainframe/videos?lnk=hm"
-                tabindex="-1"
-                >Videos</a
-              >
-            </li>
-          </ul>
-        </div>
-        <div class="ibm-mobilemenu-section">
-          <ul class="ibm-mobilemenu-mhlinks" aria-label="Discover IBM">
-            <li>
-              <div
-                data-widget="showhide"
-                data-type="panel"
-                class="ibm-show-hide ibm-widget-processed"
-              >
-                <h2>
-                  <a href="javascript:void();">Products &amp; Solutions</a>
-                </h2>
-                <div class="ibm-container-body" style="display: none;">
-                  <ul>
-                    <li>
-                      <a
-                        href="https://www.ibm.com/products?lnk=hmhpmps_bupr&amp;lnk2=link"
-                        ><span>Top products &amp; platforms</span></a
-                      >
-                    </li>
-                    <li>
-                      <a
-                        href="https://www.ibm.com/industries?lnk=hmhpmps_buin&amp;lnk2=link"
-                        ><span>Industries</span></a
-                      >
-                    </li>
-                    <li>
-                      <a
-                        href="https://www.ibm.com/artificial-intelligence?lnk=hmhpmps_buai&amp;lnk2=link"
-                        ><span>Artificial intelligence</span></a
-                      >
-                    </li>
-                    <li>
-                      <a
-                        href="https://www.ibm.com/blockchain?lnk=hmhpmps_bubc&amp;lnk2=link"
-                        ><span>Blockchain</span></a
-                      >
-                    </li>
-                    <li>
-                      <a
-                        href="https://www.ibm.com/automation?lnk=hmhpmps_buau&amp;lnk2=link"
-                        ><span>Business automation</span></a
-                      >
-                    </li>
-                    <li>
-                      <a
-                        href="https://www.ibm.com/business-operations?lnk=hmhpmps_buop&amp;lnk2=link"
-                        ><span>Business operations</span></a
-                      >
-                    </li>
-                    <li>
-                      <a
-                        href="https://www.ibm.com/cloud/products?lnk=hmhpmps_bucl&amp;lnk2=link"
-                        ><span>Cloud computing</span></a
-                      >
-                    </li>
-                    <li>
-                      <a
-                        href="https://www.ibm.com/analytics?lnk=hmhpmps_buda&amp;lnk2=link"
-                        ><span>Data &amp; Analytics</span></a
-                      >
-                    </li>
-                    <li>
-                      <a
-                        href="https://www.ibm.com/it-infrastructure/?lnk=hmhpmps_buit&amp;lnk2=link"
-                        ><span>IT infrastructure</span></a
-                      >
-                    </li>
-                    <li>
-                      <a
-                        href="https://www.ibm.com/security?lnk=hmhpmps_buse&amp;lnk2=link"
-                        ><span>Security</span></a
-                      >
-                    </li>
-                    <li>
-                      <a
-                        href="https://www.ibm.com/supply-chain?lnk=hmhpmps_busc&amp;lnk2=link"
-                        ><span>Supply chain</span></a
-                      >
-                    </li>
-                    <li>
-                      <a
-                        href="https://www.ibm.com/financing?lnk=hmhpmps_bufi&amp;lnk2=link"
-                        ><span
-                          >Payment plans for Products &amp; Solutions</span
-                        ></a
-                      >
-                    </li>
-                    <li>
-                      <a
-                        href="https://www.ibm.com/products?lnk=hmhpmps_buall&amp;lnk2=link"
-                        ><span>View all products</span></a
-                      >
-                    </li>
-                  </ul>
-                </div>
-              </div>
-            </li>
-            <li>
-              <div
-                data-widget="showhide"
-                data-type="panel"
-                class="ibm-show-hide ibm-widget-processed"
-              >
-                <h2>
-                  <a href="javascript:void();">Services &amp; Consulting</a>
-                </h2>
-                <div class="ibm-container-body" style="display: none;">
-                  <ul>
-                    <li>
-                      <a
-                        href="https://www.ibm.com/services/process?lnk=hmhpmsc_bups&amp;lnk2=link"
-                        ><span>Business process services</span></a
-                      >
-                    </li>
-                    <li>
-                      <a
-                        href="https://www.ibm.com/services/ibmix/?lnk=hmhpmsc_budbs&amp;lnk2=link"
-                        ><span>Design &amp; business strategy</span></a
-                      >
-                    </li>
-                    <li>
-                      <a
-                        href="https://www.ibm.com/services/?lnk=hmhpmsc_buhs&amp;lnk2=link"
-                        ><span>Hybrid multicloud services</span></a
-                      >
-                    </li>
-                    <li>
-                      <a
-                        href="https://www.ibm.com/talent-management?lnk=hmhpmsc_buta&amp;lnk2=link"
-                        ><span>Talent &amp; transformation</span></a
-                      >
-                    </li>
-                    <li>
-                      <a
-                        href="https://www.ibm.com/services/applications?lnk=hmhpmsc_buas&amp;lnk2=link"
-                        ><span>Application services</span></a
-                      >
-                    </li>
-                    <li>
-                      <a
-                        href="https://www.ibm.com/security/services?lnk=hmhpmsc_buse&amp;lnk2=link"
-                        ><span>Security services</span></a
-                      >
-                    </li>
-                    <li>
-                      <a
-                        href="https://www.ibm.com/services/technology-support?lnk=hmhpmsc_busv&amp;lnk2=link"
-                        ><span>Services for tech support</span></a
-                      >
-                    </li>
-                    <li>
-                      <a
-                        href="https://www.ibm.com/financing/solutions/it-services-financing?lnk=hmhpmsc_bufi&amp;lnk2=link"
-                        ><span
-                          >Payment plans for Services &amp; Consulting</span
-                        ></a
-                      >
-                    </li>
-                    <li>
-                      <a
-                        href="https://www.ibm.com/services?lnk=hmhpmsc_buall&amp;lnk2=link"
-                        ><span>View all services</span></a
-                      >
-                    </li>
-                  </ul>
-                </div>
-              </div>
-            </li>
-            <li>
-              <div
-                data-widget="showhide"
-                data-type="panel"
-                class="ibm-show-hide ibm-widget-processed"
-              >
-                <h2><a href="javascript:void();">Learn &amp; Support</a></h2>
-                <div class="ibm-container-body" style="display: none;">
-                  <ul>
-                    <li>
-                      <a
-                        href="https://www.ibm.com/support?lnk=hmhpmls_busu&amp;lnk2=link"
-                        ><span>Support</span></a
-                      >
-                    </li>
-                    <li>
-                      <a
-                        href="https://www.ibm.com/support/knowledgecenter/?lnk=hmhpmls_budc&amp;lnk2=link"
-                        ><span>Documentation</span></a
-                      >
-                    </li>
-                    <li>
-                      <a
-                        href="https://developer.ibm.com/?lnk=hmhpmls_bude&amp;lnk2=link"
-                        ><span>Developer education</span></a
-                      >
-                    </li>
-                    <li>
-                      <a
-                        href="https://www.ibm.com/training/?lnk=hmhpmls_butr&amp;lnk2=link"
-                        ><span>Training</span></a
-                      >
-                    </li>
-                    <li>
-                      <a
-                        href="https://www.ibm.com/blogs/?lnk=hmhpmls_bure&amp;lnk2=link"
-                        ><span>Resources</span></a
-                      >
-                    </li>
-                    <li>
-                      <a
-                        href="https://www.ibm.com/cloud/learn?lnk=hmhpmls_buwi&amp;lnk2=link"
-                        ><span>What is...</span></a
-                      >
-                    </li>
-                  </ul>
-                </div>
-              </div>
-            </li>
-            <li>
-              <div
-                data-widget="showhide"
-                data-type="panel"
-                class="ibm-show-hide ibm-widget-processed"
-              >
-                <h2><a href="javascript:void();">Explore more</a></h2>
-                <div class="ibm-container-body" style="display: none;">
-                  <ul>
-                    <li>
-                      <a
-                        href="https://www.ibm.com/partnerworld/public?lnk=hmhpmex_bupa&amp;lnk2=link"
-                        ><span>Partners</span></a
-                      >
-                    </li>
-                    <li>
-                      <a
-                        href="https://www.research.ibm.com/?lnk=hmhpmex_bure&amp;lnk2=link"
-                        ><span>IBM Research</span></a
-                      >
-                    </li>
-                    <li>
-                      <a
-                        href="https://www.ibm.com/ibm/us/en?lnk=hmhpmex_buab&amp;lnk2=link"
-                        ><span>About IBM</span></a
-                      >
-                    </li>
-                  </ul>
-                </div>
-              </div>
-            </li>
-            <li>
-              <div
-                data-widget="showhide"
-                data-type="panel"
-                class="ibm-show-hide ibm-widget-processed"
-              >
-                <h2><a href="javascript:void();">COVID-19</a></h2>
-                <div class="ibm-container-body" style="display: none;">
-                  <ul>
-                    <li>
-                      <a
-                        href="https://www.ibm.com/redirect-marketplace/impact/covid-19/business-solutions?lnk=hm"
-                        ><span>Business solutions</span></a
-                      >
-                    </li>
-                    <li>
-                      <a
-                        href="https://www.ibm.com/redirect-marketplace/impact/covid-19/?lnk=hm"
-                        ><span>Science and technology</span></a
-                      >
-                    </li>
-                    <li>
-                      <a
-                        href="https://newsroom.ibm.com/COVID-19?lnk=hmhpmcov_ns&amp;lnk2=link"
-                        ><span>News and resources</span></a
-                      >
-                    </li>
-                  </ul>
-                </div>
-              </div>
-            </li>
-          </ul>
-        </div>
-      </div>
-      <div class="ibm-mhplaceholder ibm-hide"></div>
-      <!-- MASTHEAD_END -->
-      <div id="ibm-content-wrapper">
-        <header role="banner" aria-labelledby="ibm-pagetitle-h1">
-          <!-- MASTHEAD_SITENAV_BEGIN -->
-          <div class="ibm-sitenav-menu-container" data-widgetprocessed="true">
-            <div class="ibm-sitenav-menu-list">
-              <ul id="primary-menu" class="menu">
-                <li
-                  id="menu-item-386"
-                  class="menu-item menu-item-type-post_type menu-item-object-page menu-item-386"
-                >
-                  <a href="../index.html" tabindex="-1">Home</a>
-                </li>
-                <li
-                  id="menu-item-4064"
-                  class="menu-item menu-item-type-post_type menu-item-object-page page_item page-item-1533 menu-item-4064"
-                >
-                  <a href="../downloads.html" tabindex="-1">Downloads</a>
-                </li>
+        <!-- MASTHEAD_SITENAV_END -->
+      </header>
+      <style>
+        #ibm-com .gsc-adBlock {
+          display: none !important;
+        }
+      </style>
 
-                <li
-                  id="menu-item-16086"
-                  class="menu-item menu-item-type-post_type menu-item-object-page current-menu-item page_item page-item-16082 current_page_item menu-item-16086"
-                >
-                  <a href="Training.html" tabindex="-1">Training</a>
-                </li>
+      <div id="content" class="site-content">
+        <!--Because the_content() works only inside a WP Loop -->
+        <div id="ibm-leadspace-head"
+          style="background-image:url(//1.cms.s81c.com/sites/default/files/2018-06-13/image-leadspace-Z-for-system-integrity-2000x500.jpg); background-repeat:no-repeat; background-size: cover; background-position: center;"
+          class="ibm-background-black-core ibm-leadspace-fluid ibm-no-border">
+          <div id="ibm-leadspace-body" class="ibm-padding-top-2 ibm-padding-bottom-2">
+            <div class="ibm-fluid ibm-padding-bottom-0">
+              <div class="ibm-col-medium-12-6 ibm-col-12-6 ">
+                <h1 class="ibm-h1 ibm-textcolor-white-core ibm-padding-bottom-0 ibm-padding-top-1"
+                  id="ibm-pagetitle-h1">
+                  <span>Redirecting...</span>
+                </h1>
 
-                <li
-                  id="menu-item-14411"
-                  class="menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-14411"
-                >
-                  <a href="https://www.ibm.com/docs/en/offline" tabindex="-1">Documentation</a>
-                  <ul class="sub-menu">
-                    <li
-                      id="menu-item-14412"
-                      class="menu-item menu-item-type-post_type menu-item-object-page menu-item-14412"
-                    >
-                      <a href="https://www.ibm.com/docs/en/offline">IBM Documentation Offline</a>
-                    </li>
-                    <li
-                      id="menu-item-14413"
-                      class="menu-item menu-item-type-custom menu-item-object-custom menu-item-14413"
-                    >
-                      <a href="https://www.ibm.com/support/knowledgecenter/"
-                        >IBM Documentation</a
-                      >
-                    </li>
-                    <li
-                      id="menu-item-22185"
-                      class="menu-item menu-item-type-post_type menu-item-object-page menu-item-22185"
-                    >
-                      <a href="../host-configuration-assistant.html"
-                        >Host Configuration Assistant for Z Development</a
-                      >
-                    </li>
-                  </ul>
-                </li>
-
-                <li
-                  id="menu-item-devops-acceleration"
-                  class="menu-item menu-item-type-post_type menu-item-object-page page_item"
-                >
-                  <a
-                    href="../DevOps_Acceleration_Program/devops-acceleration-program.html"
-                    tabindex="-1"
-                    >DevOps Acceleration Program</a
-                  >
-                </li>
-              </ul>
+                <p class="ibm-h4 ibm-light ibm-textcolor-white-core ibm-padding-top-1 ibm-padding-bottom-1">
+                  <span>This page should redirect you to the <a
+                      href="https://ibm.github.io/mainframe-downloads/Training/courses.html">Training pillar</a>
+                    page.</span>
+                </p>
+              </div>
             </div>
           </div>
-          <!-- MASTHEAD_SITENAV_END -->
-        </header>
-        <style>
-          #ibm-com .gsc-adBlock {
-            display: none !important;
-          }
-        </style>
-        <div id="content" class="site-content">
-          <!--Because the_content() works only inside a WP Loop -->
-          <div
-            id="ibm-leadspace-head"
-            style="background-image:url(//1.cms.s81c.com/sites/default/files/2018-06-13/image-leadspace-Z-for-system-integrity-2000x500.jpg); background-repeat:no-repeat; background-size: cover; background-position: center;"
-            class="ibm-background-black-core ibm-leadspace-fluid ibm-no-border"
-          >
-            <div
-              id="ibm-leadspace-body"
-              class="ibm-padding-top-2 ibm-padding-bottom-2"
-            >
-              <div class="ibm-fluid ibm-padding-bottom-0">
-                <div class="ibm-col-medium-12-6 ibm-col-12-6 ">
-                  <h1
-                    class="ibm-h1 ibm-textcolor-white-core ibm-padding-bottom-0 ibm-padding-top-1"
-                    id="ibm-pagetitle-h1"
-                  >
-                    <span>Training</span>
-                  </h1>
+        </div>
 
-                  <p
-                    class="ibm-h4 ibm-light ibm-textcolor-white-core ibm-padding-top-1 ibm-padding-bottom-1"
-                  >
-                    <span
-                      >Start your DevOps Digital Transformation Journey</span
-                    >
+
+
+        <div class="ibm-band ibm-band ibm-background-cool-gray-80 ibm-textcolor-white-core">
+          <div class="ibm-fluid ibm-padding-bottom-r1 ibm-padding-top-1">
+            <div>
+              <div class="ibm-col-12-3 ibm-col-medium-12-12 ">
+                <h2 id="contactus" class="ibm-h2 ibm-padding-top-1 ibm-padding-bottom-1 ibm-textcolor-white-core">
+                  Contact us
+                </h2>
+              </div>
+              <div class="ibm-col-12-9 ibm-col-medium-12-12 ">
+                <div class="ibm-textcolor-white-core ibm-padding-top-1 ibm-padding-bottom-0 ibm-pull-quote ibm-h3 ">
+                  <p>
+                    If you have any questions or inquiries regarding the
+                    DevOps Acceleration Program, please feel free to contact
+                    the
+                    <strong>
+                      <a style="color:white;text-decoration:underline;" href="mailto:dat@ibm.com">
+                        DevOps Acceleration Team
+                      </a>
+                    </strong>
                   </p>
                 </div>
               </div>
             </div>
           </div>
+        </div>
+        <!-- #page -->
 
-          <div class="">
-            <div class="ibm-fluid ibm-padding-bottom-r1 ibm-padding-top-r1">
-              <div>
-                <div class="ibm-col-12-3 ibm-col-medium-12-12">
-                  <h2
-                    class="ibm-h2 ibm-padding-top-0 ibm-padding-bottom-1 ibm-textcolor-blue-50"
-                  >
-                    Overview
-                  </h2>
+        <div class="gdpr-overlay"></div>
+        <div class="gdpr gdpr-privacy-preferences">
+          <div class="gdpr-wrapper">
+            <form method="post" class="gdpr-privacy-preferences-frm"
+              action="https://developer.ibm.com/mainframe/wp-admin/admin-post.php">
+              <input type="hidden" name="action" value="gdpr_update_privacy_preferences" />
+              <input type="hidden" id="update-privacy-preferences-nonce" name="update-privacy-preferences-nonce"
+                value="d46bdb5362" /><input type="hidden" name="_wp_http_referer"
+                value="/mainframe/products/devops-acceleration-program/training/" />
+              <header>
+                <div class="gdpr-box-title">
+                  <h3>Privacy Preference Center</h3>
+                  <span class="gdpr-close"></span>
                 </div>
-                <div class="ibm-col-12-9 ibm-col-medium-12-12 ">
-                  <div
-                    class="ibm-textcolor-default ibm-padding-top-0 ibm-padding-bottom-0"
-                  >
-                    <p>
-                      Our learning catalog offers you the training you need,
-                      featuring on-demand courses and live remote instructor-led
-                      training. Our focus is to equip you with the skills
-                      required to make a DevOps transformation successful.
-                    </p>
+              </header>
+              <div class="gdpr-mobile-menu">
+                <button type="button">Options</button>
+              </div>
+              <div class="gdpr-content">
+                <ul class="gdpr-tabs">
+                  <li>
+                    <button type="button" class="gdpr-tab-button gdpr-active" data-target="gdpr-consent-management">
+                      Consent Management
+                    </button>
+                  </li>
+                </ul>
+                <div class="gdpr-tab-content">
+                  <div class="gdpr-consent-management gdpr-active">
+                    <header>
+                      <h4>Consent Management</h4>
+                    </header>
+                    <div class="gdpr-info">
+                      <p></p>
+                    </div>
                   </div>
                 </div>
+                <input type="hidden" name="all_cookies" value="[]" />
               </div>
-            </div>
+              <footer>
+                <input type="submit" value="Save Preferences" />
+              </footer>
+            </form>
           </div>
-          
-          <div class="ibm-background-neutral-white-30">
-            <div class="ibm-fluid ibm-padding-bottom-r1 ibm-padding-top-r1">
-              <div>
-                <div class="ibm-col-12-3 ibm-col-medium-12-12">
-                  <h2
-                    class="ibm-h2 ibm-padding-top-0 ibm-padding-bottom-1 ibm-textcolor-blue-50"
-                  >
-                    Training
-                  </h2>
-                </div>
-                <div class="ibm-col-12-9 ibm-col-medium-12-12 ">
-                  <div
-                    class="ibm-textcolor-default ibm-padding-top-0 ibm-padding-bottom-0"
-                  >
-                    <!-- tilestart -->
+        </div>
 
-                    <div
-                      class="ibm-columns ibm-fluid ibm-widget-processed ibm-sameheight-processed"
-                      data-items=".ibm-card"
-                      data-widget="setsameheight"
-                    >
-                      <div class="card-equal ibm-col-12-4 ibm-col-medium-12-12 ibm-col-sm-12-12">
-                        <div class="ibm-card" style="height: 250px;">
-                          <div class="ibm-card__content">
-                            <h3 class="ibm-h3">
-                                DevOps Distance Learning Program
-                            </h3>
-                            <p>
-                                Instructor Led Training
-                            </p>
-                            
-                          </div>
-                          <div class="ibm-card__bottom">
-                            <p class="ibm-btn-row">
-                              <a href="adfz-instructor-led-learning.html" class="ibm-btn-pri ibm-btn-teal-50">
-                                Learn more
-                              </a>
-                            </p>
-                          </div>
-                        </div>
-                      </div>
-
-                      <div class="card-equal ibm-col-12-4 ibm-col-medium-12-6 ibm-col-sm-12-12">
-                        <div class="ibm-card" style="height: 250px;">
-                          <div class="ibm-card__content">
-                            <h3 class="ibm-h3">IBM Developer for Z</h3>
-                            <p>Self-paced learning</p>
-                          </div>
-                          <div class="ibm-card__bottom">
-                            <p class="ibm-btn-row">
-                              <a href="idz-self-paced-learning.html" class="ibm-btn-pri ibm-btn-teal-50">
-                                Learn more
-                              </a>
-                            </p>
-                          </div>
-                        </div>
-                      </div>
-
-                      <div class="card-equal ibm-col-12-4 ibm-col-medium-12-6 ibm-col-sm-12-12" >
-                        <div class="ibm-card" style="height: 250px;">
-                          <div class="ibm-card__content">
-                            <h3 class="ibm-h3">IBM Dependency Based Build</h3>
-                            <p>Self-paced learning</p>
-                          </div>
-                          <div class="ibm-card__bottom">
-                            <p class="ibm-btn-row">
-                              <a href="dbb-self-paced-learning.html" class="ibm-btn-pri ibm-btn-teal-50">
-                                Learn more
-                              </a>
-                            </p>
-                          </div>
-                        </div>
-                      </div>
-                      
-                      <div class="card-equal ibm-col-12-4 ibm-col-medium-12-6 ibm-col-sm-12-12">
-                        <div class="ibm-card" style="height: 250px;">
-                          <div class="ibm-card__content">
-                            <h3 class="ibm-h3">IBM Application Discovery & Delivery Intelligence</h3>
-                            <p>Self-paced learning</p>
-                          </div>
-                          <div class="ibm-card__bottom">
-                            <p class="ibm-btn-row">
-                              <a href="./addi-self-paced-learning.html" class="ibm-btn-pri ibm-btn-teal-50">
-                                Learn more
-                              </a>
-                            </p>
-                          </div>
-                        </div>
-                      </div>
-
-                      <div class="card-equal ibm-col-12-4 ibm-col-medium-12-6 ibm-col-sm-12-12">
-                        <div class="ibm-card" style="height: 250px;">
-                          <div class="ibm-card__content">
-
-                            <h3 class="ibm-h3">Cloud native development with IBM Z and Cloud Modernization Stack Fundamentals                       
-                            </h3>
-                            <p>Self-paced learning</p>
-                          </div>
-                          <div class="ibm-card__bottom">
-                            <p class="ibm-btn-row">
-                              <a href="./wazideveloper-self-paced-learning.html" class="ibm-btn-pri ibm-btn-teal-50">
-                                Learn more
-                              </a>
-                            </p>
-                          </div>
-                        </div>
-                      </div>
-
-                      <div class="card-equal ibm-col-12-4 ibm-col-medium-12-6 ibm-col-sm-12-12">
-                        <div class="ibm-card" style="height: 250px;">
-                          <div class="ibm-card__content">
-                            <h3 class="ibm-h3">Z DevOps Testing Fundamentals 
-                            </h3>
-                            <p>Self-paced learning</p>
-                          </div>
-                          <div class="ibm-card__bottom">
-                            <p class="ibm-btn-row">
-                              <a href="./zdevops-testing-learning.html" class="ibm-btn-pri ibm-btn-teal-50">
-                                Learn more
-                              </a>
-                            </p>
-                          </div>
-                        </div>
-                      </div>
-                      <div class="card-equal ibm-col-12-4 ibm-col-medium-12-6 ibm-col-sm-12-12">
-                        <div class="ibm-card" style="height: 250px;">
-                          <div class="ibm-card__content">
-                            <h3 class="ibm-h3">IBM watsonx Code Assistant for Z Fundamentals 
-                            </h3>
-                            <p>Self-paced learning</p>
-                          </div>
-                          <div class="ibm-card__bottom">
-                            <p class="ibm-btn-row">
-                              <a
-                                href="https://ibm.github.io/mainframe-downloads/Training/wca4z-learning.html"
-                                class="ibm-btn-pri ibm-btn-teal-50"
-                                >
-                                Learn more
-                              </a>
-                            </p>
-                          </div>
-                        </div>
-                      </div>
-                      <div class="card-equal ibm-col-12-4 ibm-col-medium-12-6 ibm-col-sm-12-12">
-                        <div class="ibm-card" style="height: 250px;">
-                          <div class="ibm-card__content">
-                            <h3 class="ibm-h3">Z DevOps CI/CD Enablement
-                            </h3>
-                            <p>Learning Collection</p>
-                          </div>
-                          <div class="ibm-card__bottom">
-                            <p class="ibm-btn-row">
-                              <a
-                                href="https://www.ibm.com/training/collection/zdevopstransformationcicdpipelineswithdbbgit"
-                                class="ibm-btn-pri ibm-btn-teal-50"
-                                >
-                                Learn more
-                              </a>
-                            </p>
-                          </div>
-                        </div>
-                      </div>
-
-                  
-                      <!-- <div class="ibm-col-12-4 ibm-col-medium-12-6 ibm-col-sm-12-12">
-
-                        </div> -->
-
-                      <!-- <div class="ibm-col-12-4 ibm-col-medium-12-6 ibm-col-sm-12-12">
-                            <div class="ibm-card">
-                                <div class="ibm-card__content">
-                                    <h3 class="ibm-h3">IDz/RDz</h3>
-                                    <p>Instructor-led Virtual Training</p>
-                                </div>
-                                <div class="ibm-card__bottom">
-                                    <p class="ibm-btn-row">
-                                        <a href="https://developer.ibm.com/mainframe/idzrdz-remote-training"
-                                            class="ibm-btn-pri ibm-btn-teal-50">Learn more</a>
-                                    </p>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="ibm-col-12-4 ibm-col-medium-12-6 ibm-col-sm-12-12">
-                            <div class="ibm-card">
-                                <div class="ibm-card__content">
-                                    <h3 class="ibm-h3">Git for ISPF Developers</h3>
-                                    <p>Instructor-led Virtual Training</p>
-                                </div>
-                                <div class="ibm-card__bottom">
-                                    <p class="ibm-btn-row">
-                                        <a href="https://developer.ibm.com/mainframe/idzrdz-remote-training"
-                                            class="ibm-btn-pri ibm-btn-teal-50">Learn more</a>
-                                    </p>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="ibm-col-12-4 ibm-col-medium-12-6 ibm-col-sm-12-12">
-
-                        </div>
-                        <div class="ibm-col-12-4 ibm-col-medium-12-6 ibm-col-sm-12-12">
-                            <div class="ibm-card">
-                                <div class="ibm-card__content">
-                                    <h3 class="ibm-h3">IBM Application Discovery</h3>
-                                    <p>Instructor-led Virtual Training</p>
-                                </div>
-                                <div class="ibm-card__bottom">
-                                    <p class="ibm-btn-row">
-                                        <a href="https://developer.ibm.com/mainframe/idzrdz-remote-training"
-                                            class="ibm-btn-pri ibm-btn-teal-50">Learn more</a>
-                                    </p>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="ibm-col-12-4 ibm-col-medium-12-6 ibm-col-sm-12-12">
-                            <div class="ibm-card">
-                                <div class="ibm-card__content">
-                                    <h3 class="ibm-h3">IBM Z Open Development</h3>
-                                    <p>Instructor-led Virtual Training</p>
-                                </div>
-                                <div class="ibm-card__bottom">
-                                    <p class="ibm-btn-row">
-                                        <a href="https://developer.ibm.com/mainframe/idzrdz-remote-training"
-                                            class="ibm-btn-pri ibm-btn-teal-50">Learn more</a>
-                                    </p>
-                                </div>
-                            </div>
-                        </div> -->
-                    </div>
-                    <!-- tileend -->
-                  </div>
-                </div>
+        <div class="gdpr gdpr-general-confirmation gdpr-delete-confirmation">
+          <div class="gdpr-wrapper">
+            <header>
+              <div class="gdpr-box-title">
+                <h3>Close your account?</h3>
+                <span class="gdpr-close"></span>
               </div>
-            </div>
-          </div>
-          
-          <div class="">
-            <div class="ibm-fluid ibm-padding-bottom-r1 ibm-padding-top-r1">
-              <div>
-                <div class="ibm-col-12-3 ibm-col-medium-12-12">
-                  <h2 class="ibm-h2 ibm-padding-top-0 ibm-padding-bottom-1 ibm-textcolor-blue-50">
-                  Resources
-                  </h2>
-                </div>
-                <div class="ibm-col-12-9 ibm-col-medium-12-12 ">
-                  <div class="ibm-textcolor-default ibm-padding-top-0 ibm-padding-bottom-0">
-                    <!-- tilestart -->
-
-                    <div
-                      class="ibm-columns ibm-fluid ibm-widget-processed ibm-sameheight-processed"
-                      data-items=".ibm-card"
-                      data-widget="setsameheight"
-                    >
-
-                      <div class="card-equal ibm-col-12-4 ibm-col-medium-12-6 ibm-col-sm-12-12">
-                        <div class="ibm-card" style="height: 250px;">
-                          <div class="ibm-card__content">
-                            <h3 class="ibm-h3">Application Discovery & Delivery Intelligence (ADDI) Accelerator</h3>
-                            <p>Introductory Materials & Guides</p>
-                          </div>
-                          <div class="ibm-card__bottom">
-                            <p class="ibm-btn-row">
-                              <a
-                                href="https://community.ibm.com/community/user/ibmz-and-linuxone/groups/community-home/librarydocuments/viewdocument?DocumentKey=4cb329ed-1515-45f1-8ec3-9c72df457ced&Step=1&CommunityKey=336bb81c-ac97-46d5-95bb-319e41258fbe&ReturnUrl=%2fcommunity%2fuser%2fibmz-and-linuxone%2fgroups%2fcommunity-home%2flibrarydocuments%2fviewdocument%3fDocumentKey%3d4cb329ed-1515-45f1-8ec3-9c72df457ced%26Step%3d1%26CommunityKey%3d336bb81c-ac97-46d5-95bb-319e41258fbe%26ReturnUrl%3d%252fcommunity%252fuser%252fibmz-and-linuxone%252fgroups%252fcommunity-home%252flibrarydocuments%252fviewdocument%253fDocumentKey%253d4cb329ed-1515-45f1-8ec3-9c72df457ced%2526Step%253d1%2526CommunityKey%253d336bb81c-ac97-46d5-95bb-319e41258fbe%2526ReturnUrl%253d%25252fcommunity%25252fuser%25252fibmz-and-linuxone%25252fviewdocument%25252faccelerator-application-discovery%25253fCommunityKey%25253d5bf125bd-1412-41a8-8843-750e6590b9c5%252526tab%25253dlibrarydocuments"
-                                class="ibm-btn-pri ibm-btn-teal-50"
-                                >Learn more</a
-                              >
-                            </p>
-                          </div>
-                        </div>
-                      </div>
-  
-                      <div class="card-equal ibm-col-12-4 ibm-col-medium-12-6 ibm-col-sm-12-12">
-                        <div class="ibm-card" style="height: 250px;">
-                          <div class="ibm-card__content">
-                            <h3 class="ibm-h3">Dependency Based Build (DBB) Accelerator</h3>
-                            <p>Getting Started - Technical Resources</p>
-                          </div>
-                          <div class="ibm-card__bottom">
-                            <p class="ibm-btn-row">
-                              <a
-                                href="https://community.ibm.com/community/user/ibmz-and-linuxone/groups/community-home/librarydocuments/viewdocument?DocumentKey=35983ecb-bd74-4b27-bdd5-2eb948587e04&Step=1&CommunityKey=336bb81c-ac97-46d5-95bb-319e41258fbe&ReturnUrl=%2fcommunity%2fuser%2fibmz-and-linuxone%2fviewdocument%2faccelerator-dependency-based-buil%3fCommunityKey%3df461c55d-159c-4a94-b708-9f7fe11d972b%26tab%3dlibrarydocuments"
-                                class="ibm-btn-pri ibm-btn-teal-50"
-                                >Learn more</a
-                              >
-                            </p>
-                          </div>
-                        </div>
-                      </div>
-                      <div class="card-equal ibm-col-12-4 ibm-col-medium-12-6 ibm-col-sm-12-12">
-                        <div class="ibm-card" style="height: 250px;">
-                          <div class="ibm-card__content">
-                            <h3 class="ibm-h3">ADFz Learning Resources</h3>
-                            <p>Training, Video and Blog Resources</p>
-                          </div>
-                          <div class="ibm-card__bottom">
-                            <p class="ibm-btn-row">
-                              <a
-                                href="adfz-learning-resources.html"
-                                class="ibm-btn-pri ibm-btn-teal-50"
-                                >Learn more</a
-                              >
-                            </p>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                    <!-- tileend -->
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <!-- 
-<div class="">
-    <div class="ibm-fluid ibm-padding-bottom-r1 ibm-padding-top-r1">
-        <div>
-            <div class="ibm-col-12-3 ibm-col-medium-12-12">
-                <h2 class="ibm-h2 ibm-padding-top-0 ibm-padding-bottom-1 ibm-textcolor-blue-50">Whitepapers</h2>
-            </div>
-            <div class="ibm-col-12-9 ibm-col-medium-12-12 ">
-                <div class="ibm-textcolor-default ibm-padding-top-0 ibm-padding-bottom-0">
-
-                    <div class="ibm-columns ibm-fluid" data-items=".ibm-card" data-widget="setsameheight">
-
-                        <div class="ibm-col-12-4 ibm-col-medium-12-6 ibm-col-sm-12-12">
-                            <div class="ibm-card">
-                                <div class="ibm-card__image">
-                             
-                                </div>
-                                <div class="ibm-card__content">
-                                    <h3 class="ibm-h3">The right offerings and strategy for the Internet of Things
-                                    </h3>
-                                    <p>IBM is named a leader in The Forrester Wave: loT Software Platforms, Q4 2016
-                                    </p>
-                                    <p class="ibm-btn-row">
-                                        <a href="javascript:;" class="ibm-btn-pri ibm-btn-teal-50">Learn more</a>
-                                    </p>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="ibm-col-12-4 ibm-col-medium-12-6 ibm-col-sm-12-12">
-                            <div class="ibm-card">
-                                <div class="ibm-card__image">
-                      
-                                </div>
-                                <div class="ibm-card__content">
-                                    <h3 class="ibm-h3">Move to the cloud and reap the financial benefit</h3>
-                                    <p>With POWER8 servers, you can process big data and analytics workloads in the
-                                        cloud – and reduce costs</p>
-                                    <p class="ibm-btn-row">
-                                        <a href="javascript:;" class="ibm-btn-pri ibm-btn-teal-50">Learn more</a>
-                                    </p>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="ibm-col-12-4 ibm-col-medium-12-6 ibm-col-sm-12-12">
-                            <div class="ibm-card">
-                                <div class="ibm-card__image">
-                   
-                                </div>
-                                <div class="ibm-card__content">
-                                    <h3 class="ibm-h3">Move to the cloud and reap the financial benefit</h3>
-                                    <p>With POWER8 servers, you can process big data and analytics workloads in the
-                                        cloud – and reduce costs</p>
-                                    <p class="ibm-btn-row">
-                                        <a href="javascript:;" class="ibm-btn-pri ibm-btn-teal-50">Learn more</a>
-                                    </p>
-                                </div>
-
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-</div> -->
-          <!-- Page Content -->
-        </div>
-        <!-- #content -->
-      </div>
-      <!-- end of ibm-content-wrapper -->
-
-      <p
-        class="ibm-ind-link ibm-nospacing ibm-icononly ibm-btt-auto ibm-hidden-small"
-      >
-        <a
-          class="ibm-nospacing ibm-top-link"
-          aria-label="Back to top"
-          href="https://developer.ibm.com/mainframe/products/devops-acceleration-program/training/#top"
-          tabindex="0"
-          >Back to top</a
-        >
-      </p>
-
-      <footer role="contentinfo" aria-label="IBM" id="themeFooter">
-        <div id="boomer-footer" class="boomer_footer_menu"></div>
-        <div id="dw-footer" class="ibm-alternate ibm-padding-normal">
-          <div class="ibm-columns ibm-padding-bottom-0"></div>
-        </div>
-      </footer>
-    </div>
-
-    <div class="ibm-band ibm-band ibm-background-cool-gray-80 ibm-textcolor-white-core">
-      <div class="ibm-fluid ibm-padding-bottom-r1 ibm-padding-top-1">
-        <div>
-          <div class="ibm-col-12-3 ibm-col-medium-12-12 ">
-            <h2 id="contactus" class="ibm-h2 ibm-padding-top-1 ibm-padding-bottom-1 ibm-textcolor-white-core">
-              Contact us
-            </h2>
-          </div>
-          <div class="ibm-col-12-9 ibm-col-medium-12-12 ">
-            <div class="ibm-textcolor-white-core ibm-padding-top-1 ibm-padding-bottom-0 ibm-pull-quote ibm-h3 ">
+            </header>
+            <div class="gdpr-content">
               <p>
-                If you have any questions or inquiries regarding the
-                DevOps Acceleration Program, please feel free to contact
-                the
-                <strong>
-                  <a style="color:white;text-decoration:underline;" href="mailto:dat@ibm.com">
-                    DevOps Acceleration Team
-                  </a>
-                </strong>
+                Your account will be closed and all data will be permanently deleted
+                and cannot be recovered. Are you sure?
               </p>
             </div>
+            <footer>
+              <button class="gdpr-delete-account">Continue</button>
+              <button class="gdpr-cancel">Cancel</button>
+            </footer>
           </div>
         </div>
-      </div>
-    </div>
-    <!-- #page -->
 
-    <div class="gdpr-overlay"></div>
-    <div class="gdpr gdpr-privacy-preferences">
-      <div class="gdpr-wrapper">
-        <form
-          method="post"
-          class="gdpr-privacy-preferences-frm"
-          action="https://developer.ibm.com/mainframe/wp-admin/admin-post.php"
-        >
-          <input
-            type="hidden"
-            name="action"
-            value="gdpr_update_privacy_preferences"
-          />
-          <input
-            type="hidden"
-            id="update-privacy-preferences-nonce"
-            name="update-privacy-preferences-nonce"
-            value="d46bdb5362"
-          /><input
-            type="hidden"
-            name="_wp_http_referer"
-            value="/mainframe/products/devops-acceleration-program/training/"
-          />
-          <header>
-            <div class="gdpr-box-title">
-              <h3>Privacy Preference Center</h3>
-              <span class="gdpr-close"></span>
-            </div>
-          </header>
-          <div class="gdpr-mobile-menu">
-            <button type="button">Options</button>
-          </div>
-          <div class="gdpr-content">
-            <ul class="gdpr-tabs">
-              <li>
-                <button
-                  type="button"
-                  class="gdpr-tab-button gdpr-active"
-                  data-target="gdpr-consent-management"
-                >
-                  Consent Management
-                </button>
-              </li>
-            </ul>
-            <div class="gdpr-tab-content">
-              <div class="gdpr-consent-management gdpr-active">
-                <header>
-                  <h4>Consent Management</h4>
-                </header>
-                <div class="gdpr-info">
-                  <p></p>
-                </div>
-              </div>
-            </div>
-            <input type="hidden" name="all_cookies" value="[]" />
-          </div>
-          <footer>
-            <input type="submit" value="Save Preferences" />
-          </footer>
-        </form>
-      </div>
-    </div>
+        <script>
+          jQuery(document).ready(function ($) {
+            var dcName = "mainframe";
+            // $('a').each(function(){
+            //   if(this.href.match('bluemix.net')){
+            //     if(this.search){
+            //       this.href = this.href + '&cm_sp=dw-bluemix-_-'+dcName+'-_-devcenter';
+            //     }else{
+            //       this.href = this.href + '?cm_sp=dw-bluemix-_-'+dcName+'-_-devcenter';
+            //     }
+            //   }
+            // });
 
-    <div class="gdpr gdpr-general-confirmation gdpr-delete-confirmation">
-      <div class="gdpr-wrapper">
-        <header>
-          <div class="gdpr-box-title">
-            <h3>Close your account?</h3>
-            <span class="gdpr-close"></span>
-          </div>
-        </header>
-        <div class="gdpr-content">
-          <p>
-            Your account will be closed and all data will be permanently deleted
-            and cannot be recovered. Are you sure?
-          </p>
-        </div>
-        <footer>
-          <button class="gdpr-delete-account">Continue</button>
-          <button class="gdpr-cancel">Cancel</button>
-        </footer>
-      </div>
-    </div>
+            jQuery('a[href*="bluemix.net"]').each(function () {
+              if (this.search) {
+                this.href =
+                  this.href + "&cm_sp=dw-bluemix-_-" + dcName + "-_-devcenter";
+              } else {
+                this.href =
+                  this.href + "?cm_sp=dw-bluemix-_-" + dcName + "-_-devcenter";
+              }
+            });
+          });
+        </script>
+        <script type="text/javascript" src="./Training_files/navigation.js"></script>
+        <script type="text/javascript" src="./Training_files/skip-link-focus-fix.js"></script>
+        <script type="text/javascript" src="./Training_files/tactic.js"></script>
+        <script type="text/javascript" src="./Training_files/tacticbindlinks.js"></script>
+        <script type="text/javascript" src="./Training_files/new-tab.min.js"></script>
+        <script type="text/javascript" src="./Training_files/wp-embed.min.js"></script>
 
-    <script>
-      jQuery(document).ready(function($) {
-        var dcName = "mainframe";
-        // $('a').each(function(){
-        //   if(this.href.match('bluemix.net')){
-        //     if(this.search){
-        //       this.href = this.href + '&cm_sp=dw-bluemix-_-'+dcName+'-_-devcenter';
-        //     }else{
-        //       this.href = this.href + '?cm_sp=dw-bluemix-_-'+dcName+'-_-devcenter';
-        //     }
-        //   }
-        // });
-
-        jQuery('a[href*="bluemix.net"]').each(function() {
-          if (this.search) {
-            this.href =
-              this.href + "&cm_sp=dw-bluemix-_-" + dcName + "-_-devcenter";
-          } else {
-            this.href =
-              this.href + "?cm_sp=dw-bluemix-_-" + dcName + "-_-devcenter";
+        <script>
+          /* this is where we are going to control the main menu */
+          function changeMenu(links) {
+            IBMCore.common.module.masthead.editProfileMenu({
+              action: "replace",
+              links: links,
+            });
           }
-        });
-      });
-    </script>
-    <script
-      type="text/javascript"
-      src="./Training_files/navigation.js"
-    ></script>
-    <script
-      type="text/javascript"
-      src="./Training_files/skip-link-focus-fix.js"
-    ></script>
-    <script type="text/javascript" src="./Training_files/tactic.js"></script>
-    <script
-      type="text/javascript"
-      src="./Training_files/tacticbindlinks.js"
-    ></script>
-    <script
-      type="text/javascript"
-      src="./Training_files/new-tab.min.js"
-    ></script>
-    <script
-      type="text/javascript"
-      src="./Training_files/wp-embed.min.js"
-    ></script>
 
-    <script>
-      /* this is where we are going to control the main menu */
-      function changeMenu(links) {
-        IBMCore.common.module.masthead.editProfileMenu({
-          action: "replace",
-          links: links,
-        });
-      }
-
-      var setMainMenu = function() {
-        var userLinks = [
-          {
-            title: "My IBM",
-            url: "https://myibm.ibm.com/dashboard/?lnk=mmi",
-          },
-          {
-            title: "Sign In",
-            url:
-              "https://developer.ibm.com/sso/login?d=https%3A%2F%2Fdeveloper.ibm.com%2Fmainframe%2Fproducts%2Fdevops-acceleration-program%2Ftraining&lang=en_US",
-          },
-          {
-            title: "Register",
-            url:
-              "https://developer.ibm.com/sso/register?lang=en_US&d=https%3A%2F%2Fdeveloper.ibm.com%2Fmainframe%2Fproducts%2Fdevops-acceleration-program%2Ftraining",
-          },
-        ];
-        changeMenu(userLinks);
-      };
-
-      IBMCore.common.module.masthead.subscribe(
-        "profileMenuReady",
-        "customjs",
-        setMainMenu
-      );
-    </script>
-    <script>
-      (function($) {
-        $(document).ready(function() {
-          /* prevent the # links in the main menu from firing */
-          $(".ibm-sitenav-menu-list #primary-menu a").on(
-            "click.stopFakeLinks",
-            function(e) {
-              $this = $(this);
-              if ($this.attr("href") === "#") {
-                return false;
-              }
-            }
-          );
-
-          /* bind the feedback click evnet */
-          jQuery("#dw-footer .ibm-feedbacklink a").on("click", function(evt) {
-            evt.preventDefault();
-            var iframeWidth = 970;
-            if (window.innerWidth < 900) {
-              iframeWidth = window.innerWidth - 80;
-            }
-            IBMCore.common.widget.surveyccfintercept.initFeedback({
-              survey: {
-                height: 700,
-                id: "web-exp",
-                metaData: "",
-                type: "medallia",
-                width: iframeWidth,
+          var setMainMenu = function () {
+            var userLinks = [
+              {
+                title: "My IBM",
+                url: "https://myibm.ibm.com/dashboard/?lnk=mmi",
               },
-            });
-          });
-          //testing out the alpha helper
-          $("[data-alpha]").each(function(i) {
-            $elm = $(this);
-            var bg = $elm
-              .css("backgroundColor")
-              .replace(/[rgb(]/g, "")
-              .replace(/ /g, "")
-              .replace(/[)]/g, "");
-            var alpha = $elm.data("alpha") / 100;
-            $elm.css(
-              "cssText",
-              "background-color: rgba(" + bg + "," + alpha + ") !important;"
-            );
-          });
-          //testing out the panel slider
-          $(".pn-sliding-panels").each(function(i) {
-            $elm = $(this);
-            //get the width of the active panel
-            var activeWidth = $elm.data("openamount"),
-              panelCount = $elm.data("panelcount"),
-              inactiveWidth = (100 - activeWidth) / (panelCount - 1);
-            //set the first slide as active - later, allow it to be set
-            $elm.find(".pn-panel").each(function(i, item) {
-              $panel = $(item);
-              $panel.data("closedwidth", inactiveWidth);
-              $panel.data("openwidth", activeWidth);
-              if (i == 0) {
-                $panel
-                  .addClass("pn-panel__active")
-                  .css({ width: activeWidth + "%" });
-              } else {
-                $panel.css({ width: inactiveWidth + "%" });
-              }
-            });
+              {
+                title: "Sign In",
+                url:
+                  "https://developer.ibm.com/sso/login?d=https%3A%2F%2Fdeveloper.ibm.com%2Fmainframe%2Fproducts%2Fdevops-acceleration-program%2Ftraining&lang=en_US",
+              },
+              {
+                title: "Register",
+                url:
+                  "https://developer.ibm.com/sso/register?lang=en_US&d=https%3A%2F%2Fdeveloper.ibm.com%2Fmainframe%2Fproducts%2Fdevops-acceleration-program%2Ftraining",
+              },
+            ];
+            changeMenu(userLinks);
+          };
 
-            $elm.on("click.slide", ".pn-panel", function(e) {
-              $this = $(this);
-              //console.info('clicked')
-              if ($this.hasClass("pn-panel__active")) {
-                //allow for the links in the active panel to be clicked
-                //console.info('im open, let the links through')
-              } else {
-                e.preventDefault();
-                //set the width of the currently active panel to the closed amount
-                var $active = $this
-                  .parents(".pn-sliding-panels")
-                  .find(".pn-panel__active");
-                $active
-                  .css({ width: $active.data("closedwidth") + "%" })
-                  .removeClass("pn-panel__active");
-                $this
-                  .addClass("pn-panel__active")
-                  .css({ width: $this.data("openwidth") + "%" });
-              }
-            });
-          });
-        });
-      })(jQuery);
-    </script>
+          IBMCore.common.module.masthead.subscribe(
+            "profileMenuReady",
+            "customjs",
+            setMainMenu
+          );
+        </script>
+        <script>
+          (function ($) {
+            $(document).ready(function () {
+              /* prevent the # links in the main menu from firing */
+              $(".ibm-sitenav-menu-list #primary-menu a").on(
+                "click.stopFakeLinks",
+                function (e) {
+                  $this = $(this);
+                  if ($this.attr("href") === "#") {
+                    return false;
+                  }
+                }
+              );
 
-    <div id="ibm-overlay-backdrop"></div>
-    <div class="pn-modal-overlay" style="display: none;"></div>
-    <div class="pn-modal" style="display: none;">
-      <div class="pn-modal-wrap">
-        <div class="pn-modal-hd">Header Here</div>
-        <div class="pn-modal-bd"></div>
-        <div class="pn-modal-ft"></div>
-        <a
-          href="https://developer.ibm.com/mainframe/products/devops-acceleration-program/training/#"
-          class="pn-modal-close"
-          >x</a
-        >
-      </div>
-    </div>
-    <div id="ibm-mobilemenu-screen"></div>
-  </body>
+              /* bind the feedback click evnet */
+              jQuery("#dw-footer .ibm-feedbacklink a").on("click", function (evt) {
+                evt.preventDefault();
+                var iframeWidth = 970;
+                if (window.innerWidth < 900) {
+                  iframeWidth = window.innerWidth - 80;
+                }
+                IBMCore.common.widget.surveyccfintercept.initFeedback({
+                  survey: {
+                    height: 700,
+                    id: "web-exp",
+                    metaData: "",
+                    type: "medallia",
+                    width: iframeWidth,
+                  },
+                });
+              });
+              //testing out the alpha helper
+              $("[data-alpha]").each(function (i) {
+                $elm = $(this);
+                var bg = $elm
+                  .css("backgroundColor")
+                  .replace(/[rgb(]/g, "")
+                  .replace(/ /g, "")
+                  .replace(/[)]/g, "");
+                var alpha = $elm.data("alpha") / 100;
+                $elm.css(
+                  "cssText",
+                  "background-color: rgba(" + bg + "," + alpha + ") !important;"
+                );
+              });
+              //testing out the panel slider
+              $(".pn-sliding-panels").each(function (i) {
+                $elm = $(this);
+                //get the width of the active panel
+                var activeWidth = $elm.data("openamount"),
+                  panelCount = $elm.data("panelcount"),
+                  inactiveWidth = (100 - activeWidth) / (panelCount - 1);
+                //set the first slide as active - later, allow it to be set
+                $elm.find(".pn-panel").each(function (i, item) {
+                  $panel = $(item);
+                  $panel.data("closedwidth", inactiveWidth);
+                  $panel.data("openwidth", activeWidth);
+                  if (i == 0) {
+                    $panel
+                      .addClass("pn-panel__active")
+                      .css({ width: activeWidth + "%" });
+                  } else {
+                    $panel.css({ width: inactiveWidth + "%" });
+                  }
+                });
+
+                $elm.on("click.slide", ".pn-panel", function (e) {
+                  $this = $(this);
+                  //console.info('clicked')
+                  if ($this.hasClass("pn-panel__active")) {
+                    //allow for the links in the active panel to be clicked
+                    //console.info('im open, let the links through')
+                  } else {
+                    e.preventDefault();
+                    //set the width of the currently active panel to the closed amount
+                    var $active = $this
+                      .parents(".pn-sliding-panels")
+                      .find(".pn-panel__active");
+                    $active
+                      .css({ width: $active.data("closedwidth") + "%" })
+                      .removeClass("pn-panel__active");
+                    $this
+                      .addClass("pn-panel__active")
+                      .css({ width: $this.data("openwidth") + "%" });
+                  }
+                });
+              });
+            });
+          })(jQuery);
+        </script>
+
+        <div id="ibm-overlay-backdrop"></div>
+        <div class="pn-modal-overlay" style="display: none;"></div>
+        <div class="pn-modal" style="display: none;">
+          <div class="pn-modal-wrap">
+            <div class="pn-modal-hd">Header Here</div>
+            <div class="pn-modal-bd"></div>
+            <div class="pn-modal-ft"></div>
+            <a href="https://developer.ibm.com/mainframe/products/devops-acceleration-program/training/#"
+              class="pn-modal-close">x</a>
+          </div>
+        </div>
+        <div id="ibm-mobilemenu-screen"></div>
+</body>
+
 </html>


### PR DESCRIPTION
Training.html has been renamed to Courses.html, and devops-acceleration-program.html has been renamed to dap.html.

The old pages have been adjusted to redirect to the new pages, with the appropriate content displayed while redirecting.

Additionally, the "News, Updates, & Resources" pane on dap.html has been hidden.