### PR TITLE
Updating Partner Tools page

### DIFF
--- a/DevOps_Acceleration_Program/partner-tools.html
+++ b/DevOps_Acceleration_Program/partner-tools.html
@@ -1076,7 +1076,7 @@
         <div id="content" class="site-content">
           <div class="ibm-fluid content-area-restricted pnpagepost">
             <header class="pagepost-entry-header">
-              <h1 class="entry-title">Partner Tools (Outdated) </h1>
+              <h1 class="entry-title">Partner Tools</h1>
             </header>
             <!-- .entry-header -->
             <div id="primary" class="content-area">

--- a/DevOps_Acceleration_Program/partner-tools.html
+++ b/DevOps_Acceleration_Program/partner-tools.html
@@ -7,7 +7,7 @@
   class="no-applicationcache geolocation history postmessage svg websockets localstorage sessionstorage websqldatabase webworkers hashchange pointerevents canvas audio canvastext video webgl cssgradients multiplebgs opacity rgba inlinesvg hsla supports svgclippaths smil no-touchevents fontface no-generatedcontent textshadow cssanimations backgroundsize borderimage borderradius boxshadow csscolumns csscolumns-width csscolumns-span csscolumns-fill csscolumns-gap csscolumns-rule csscolumns-rulecolor csscolumns-rulestyle csscolumns-rulewidth csscolumns-breakbefore csscolumns-breakafter csscolumns-breakinside flexbox flexboxlegacy cssreflections csstransforms csstransforms3d csstransitions indexeddb indexeddb-deletedatabase js ibm-v18 ibm-cxtype-4g hires mac chrome chrome8 webkit webkit5 ibm-grid-xlarge"
 >
   <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <meta http-equiv="refresh" content="2;url=https://ibm.github.io/mainframe-downloads/DevOps_Acceleration_Program/dap.html" />
     <!-- SITE MON : START (DO NOT DELETE) -->
     <!-- developerWorks monitoring token -->
     <!-- SITE MON : END (DO NOT DELETE) -->
@@ -1076,13 +1076,17 @@
         <div id="content" class="site-content">
           <div class="ibm-fluid content-area-restricted pnpagepost">
             <header class="pagepost-entry-header">
-              <h1 class="entry-title">Partner Tools</h1>
+              <h1 class="entry-title">Partner Tools (Outdated) </h1>
             </header>
             <!-- .entry-header -->
             <div id="primary" class="content-area">
               <main id="main" class="site-main" role="main" aria-label="">
-                <div class="entry-content">
+                <p>
+                  <span>This page should redirect you to the <a href="https://ibm.github.io/mainframe-downloads/DevOps_Acceleration_Program/dap.html">DevOps Acceleration Program</a> page.</span>
+                </p>
+                <div class="entry-content" style="display: none;">
                   <!--Because the_content() works only inside a WP Loop -->
+                  
                   <p>
                     Our business partner RRMAC has developed the following tools
                     and utilities to help automate the migration from a library


### PR DESCRIPTION
The partner tools page on the DAP website is outdated. 
This change hides all content on the page and redirects it to the main page. 

